### PR TITLE
Fix release date timezone cutoff

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ LIBRARYSYNC_GZIP_ENABLED=true
 LIBRARYSYNC_GZIP_MIN_SIZE=500
 # Enable or disable dashboard statistics (set to false to disable)
 LIBRARYSYNC_ENABLE_DASHBOARD_STATS=true
+# Time zone used when deciding whether date-only movie/episode releases are "released" yet.
+LIBRARYSYNC_RELEASE_DATE_TIMEZONE=UTC
 
 # OAuth
 TRAKT_CLIENT_ID=your_trakt_client_id

--- a/backend/src/librarysync/api/routes_stremio_addon_public.py
+++ b/backend/src/librarysync/api/routes_stremio_addon_public.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from importlib import metadata
 from typing import Any, Literal
 
@@ -10,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from librarysync.api.deps import get_db
 from librarysync.core.catalog_ordering import apply_catalog_ordering, build_show_progress_subquery
+from librarysync.core.release_dates import get_release_now_date
 from librarysync.core.stremio_addon import (
     DEFAULT_PAGE_SIZE,
     DEFAULT_SHOW_IN_HOME,
@@ -277,7 +277,7 @@ async def _build_watchlist_query(
     is_show_catalog = normalized_media_type in {"tv", "anime", "series"}
     if statuses:
         if is_show_catalog:
-            now_date = datetime.now(timezone.utc).date()
+            now_date = get_release_now_date()
             query, _ = apply_show_status_filter(
                 query,
                 user_id=user_id,
@@ -296,7 +296,7 @@ async def _build_in_progress_query(
     catalog: dict | None,
     search: str | None,
 ):
-    now_date = datetime.now(timezone.utc).date()
+    now_date = get_release_now_date()
     progress_subq = build_show_progress_subquery(user_id, now_date)
     query = (
         select(MediaItem)
@@ -370,6 +370,7 @@ def _apply_ordering(
         release_date_col=release_date_col,
         base_media_id_col=base_media_id_col,
         tie_breaker_col=tie_breaker_col,
+        now_date=get_release_now_date(),
     )
 
 

--- a/backend/src/librarysync/api/routes_watchlist.py
+++ b/backend/src/librarysync/api/routes_watchlist.py
@@ -17,6 +17,7 @@ from librarysync.core.catalog_ordering import (
     apply_catalog_ordering,
 )
 from librarysync.core.publicmetadb import is_publicmetadb_sync_enabled
+from librarysync.core.release_dates import get_release_now_date
 from librarysync.core.watch_pipeline import enqueue_new_item_job
 from librarysync.core.watchlist import (
     apply_combined_status_filter,
@@ -534,7 +535,7 @@ async def list_watchlist_items(
     )
 
     if status and status != "all" and status_filter_values:
-        filter_now_date = datetime.now(timezone.utc).date()
+        filter_now_date = get_release_now_date()
         query = apply_combined_status_filter(
             query,
             user_id=current_user.id,
@@ -598,6 +599,7 @@ async def list_watchlist_items(
         release_date_col=release_date_expr,
         base_media_id_col=MediaItem.id,
         tie_breaker_col=WatchlistItem.id,
+        now_date=get_release_now_date(),
     )
     query = query.offset(offset).limit(limit)
     result = await db.execute(query)
@@ -626,7 +628,7 @@ async def list_watchlist_items(
                 )
             )
 
-    now_date = datetime.now(timezone.utc).date()
+    now_date = get_release_now_date()
     tv_media_ids = [media.id for _, media in rows if media.media_type == "tv"]
     progress_map = await _get_show_progress_bulk(db, current_user.id, tv_media_ids)
     items = []
@@ -772,7 +774,7 @@ async def mark_watchlist_item_watched(
     if media_item.media_type == "tv":
         # Logic to find next episode:
         # a) Get all released episodes
-        now_date = datetime.now(timezone.utc).date()
+        now_date = get_release_now_date()
         episodes_result = await db.execute(
             select(EpisodeItem)
             .where(
@@ -900,7 +902,7 @@ async def _get_show_progress_bulk(
     if not media_item_ids:
         return {}
 
-    now = datetime.now(timezone.utc).date()
+    now = get_release_now_date()
     released_subq = (
         select(
             EpisodeItem.show_media_item_id.label("media_item_id"),
@@ -992,7 +994,7 @@ async def _refresh_watchlist_statuses_for_filter(
     if not rows:
         return
 
-    now_date = datetime.now(timezone.utc).date()
+    now_date = get_release_now_date()
     tv_media_ids = [media.id for _, media in rows if media.media_type == "tv"]
     progress_map = await _get_show_progress_bulk(db, user_id, tv_media_ids)
     status_changed = False

--- a/backend/src/librarysync/config.py
+++ b/backend/src/librarysync/config.py
@@ -42,6 +42,7 @@ class Settings:
     enable_dashboard_stats: bool
     trakt_max_batch_size: int
     simkl_max_batch_size: int
+    release_date_timezone: str
 
 
 def load_settings() -> Settings:
@@ -114,6 +115,9 @@ def load_settings() -> Settings:
         ),
         simkl_max_batch_size=int(
             _get_env("LIBRARYSYNC_SIMKL_MAX_BATCH_SIZE", "750") or "750"
+        ),
+        release_date_timezone=(
+            _get_env("LIBRARYSYNC_RELEASE_DATE_TIMEZONE", "UTC") or "UTC"
         ),
     )
 

--- a/backend/src/librarysync/core/catalog_ordering.py
+++ b/backend/src/librarysync/core/catalog_ordering.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date
 from typing import Literal
 
 from sqlalchemy import Float, cast, func, select
 from sqlalchemy.sql import ColumnElement
 from sqlalchemy.sql.selectable import Select
 
+from librarysync.core.release_dates import get_release_now_date
 from librarysync.db.models import EpisodeItem, WatchedItem
 
 CatalogOrderBy = Literal[
@@ -50,7 +51,7 @@ def apply_catalog_ordering(
         )
         order_expression = last_watched_subq.c.last_watched_at
     elif order_by in {"episodes_left", "progress"}:
-        now_date = now_date or datetime.now(timezone.utc).date()
+        now_date = now_date or get_release_now_date()
         progress_subq = build_show_progress_subquery(user_id, now_date)
         updated_query = updated_query.outerjoin(
             progress_subq,
@@ -63,7 +64,7 @@ def apply_catalog_ordering(
                 progress_subq.c.total_released, 0
             )
     elif order_by == "last_episode_air_date":
-        now_date = now_date or datetime.now(timezone.utc).date()
+        now_date = now_date or get_release_now_date()
         last_episode_subq = _build_last_episode_air_subquery(now_date)
         updated_query = updated_query.outerjoin(
             last_episode_subq,
@@ -71,7 +72,7 @@ def apply_catalog_ordering(
         )
         order_expression = last_episode_subq.c.last_episode_air_date
     elif order_by == "next_episode_air_date":
-        now_date = now_date or datetime.now(timezone.utc).date()
+        now_date = now_date or get_release_now_date()
         next_episode_subq = _build_next_episode_air_subquery(now_date)
         updated_query = updated_query.outerjoin(
             next_episode_subq,

--- a/backend/src/librarysync/core/release_dates.py
+++ b/backend/src/librarysync/core/release_dates.py
@@ -1,0 +1,31 @@
+import logging
+from datetime import date, datetime, timezone
+from functools import lru_cache
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from librarysync.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=16)
+def _resolve_timezone(timezone_name: str):
+    try:
+        return ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError:
+        logger.warning(
+            "Unknown release date timezone '%s'; falling back to UTC",
+            timezone_name,
+        )
+        return timezone.utc
+
+
+def get_release_now_date(
+    now: datetime | None = None,
+    timezone_name: str | None = None,
+) -> date:
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    release_timezone = _resolve_timezone(timezone_name or settings.release_date_timezone)
+    return current.astimezone(release_timezone).date()

--- a/backend/src/librarysync/core/watchlist.py
+++ b/backend/src/librarysync/core/watchlist.py
@@ -10,6 +10,7 @@ from librarysync.connectors.metadata.base import EpisodeMetadataProvider
 from librarysync.core.catalog_ordering import build_show_progress_subquery
 from librarysync.core.metadata_providers import MetadataProviderService
 from librarysync.core.rate_limiter import RATE_LIMITER
+from librarysync.core.release_dates import get_release_now_date
 from librarysync.db.models import (
     EpisodeItem,
     MediaItem,
@@ -492,7 +493,7 @@ async def refresh_watchlist_from_history(
     if not media_item:
         return
 
-    now_date = datetime.now(timezone.utc).date()
+    now_date = get_release_now_date()
     if media_item.media_type == "movie":
         watch_result = await db.execute(
             select(WatchedItem.id)
@@ -536,7 +537,7 @@ async def evaluate_show_watchlist_status(
         return
 
     # Find released episodes
-    now_date = datetime.now(timezone.utc).date()
+    now_date = get_release_now_date()
 
     result = await db.execute(
         select(EpisodeItem).where(

--- a/backend/src/librarysync/jobs/watchlist_refresh.py
+++ b/backend/src/librarysync/jobs/watchlist_refresh.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy import exists, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from librarysync.core.release_dates import get_release_now_date
 from librarysync.core.scheduler import (
     claim_scheduled_job,
     complete_scheduled_job,
@@ -98,7 +99,7 @@ async def _load_watchlist_rows_for_refresh(
         return (await db.execute(base_query)).all()
 
     now = datetime.now(timezone.utc)
-    now_date = now.date()
+    now_date = get_release_now_date(now)
     last_run_date = last_run_at.date()
 
     media_ids: set[str] = set()
@@ -245,7 +246,7 @@ async def _refresh_movie_status(
     item: WatchlistItem,
     media: MediaItem,
 ) -> None:
-    now_date = datetime.now(timezone.utc).date()
+    now_date = get_release_now_date()
     has_watched = item.status == "watched"
     new_status = determine_movie_watchlist_status(
         media,

--- a/backend/tests/test_release_dates.py
+++ b/backend/tests/test_release_dates.py
@@ -1,0 +1,29 @@
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(PROJECT_ROOT / "src"))
+
+from librarysync.core.release_dates import get_release_now_date  # noqa: E402
+
+
+class TestReleaseDates(unittest.TestCase):
+    def test_release_date_uses_configured_timezone(self) -> None:
+        now = datetime(2026, 3, 18, 1, 30, tzinfo=timezone.utc)
+
+        result = get_release_now_date(now, "America/Los_Angeles")
+
+        self.assertEqual(result.isoformat(), "2026-03-17")
+
+    def test_invalid_timezone_falls_back_to_utc(self) -> None:
+        now = datetime(2026, 3, 18, 1, 30, tzinfo=timezone.utc)
+
+        result = get_release_now_date(now, "Not/A_Real_Timezone")
+
+        self.assertEqual(result.isoformat(), "2026-03-18")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a configurable release-date timezone so date-only episode and movie releases are evaluated in local time instead of UTC midnight
- use that cutoff consistently across watchlist status evaluation, watchlist refresh, and public Stremio catalog queries/orderings
- add focused tests for the release-date helper and document the new env var

## Testing
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q backend/tests/test_release_dates.py backend/tests/test_metadata_episode_refresh.py backend/tests/test_watchlist_filters.py
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check backend/src/librarysync/config.py backend/src/librarysync/core/release_dates.py backend/src/librarysync/core/catalog_ordering.py backend/src/librarysync/core/watchlist.py backend/src/librarysync/api/routes_watchlist.py backend/src/librarysync/api/routes_stremio_addon_public.py backend/src/librarysync/jobs/watchlist_refresh.py backend/tests/test_release_dates.py