### PR TITLE
Add watched shows to watchlist from history

### DIFF
--- a/backend/src/librarysync/core/watch_pipeline.py
+++ b/backend/src/librarysync/core/watch_pipeline.py
@@ -22,6 +22,7 @@ from librarysync.core.publicmetadb import is_publicmetadb_sync_enabled
 from librarysync.core.watchlist import (
     backfill_show_episodes,
     check_and_update_watchlist,
+    ensure_show_watchlist_item,
     refresh_watchlist_from_history,
 )
 from librarysync.db.models import (
@@ -311,6 +312,12 @@ async def process_new_item_job(db: AsyncSession, job: OutboxJob) -> None:
         await refresh_episode_metadata(db, watched.user_id, media_item, episode_item)
     if media_item and media_item.media_type in {"tv", "anime"}:
         await backfill_show_episodes(db, watched.user_id, media_item)
+        await ensure_show_watchlist_item(
+            db,
+            watched.user_id,
+            media_item,
+            watched_at=watched.watched_at,
+        )
     if media_item:
         await check_and_update_watchlist(
             db,

--- a/backend/src/librarysync/core/watch_pipeline.py
+++ b/backend/src/librarysync/core/watch_pipeline.py
@@ -310,15 +310,19 @@ async def process_new_item_job(db: AsyncSession, job: OutboxJob) -> None:
     await enrich_watched_metadata(db, watched.user_id, media_item, episode_item)
     if episode_item and media_item:
         await refresh_episode_metadata(db, watched.user_id, media_item, episode_item)
+    show_status_evaluated = False
     if media_item and media_item.media_type in {"tv", "anime"}:
         await backfill_show_episodes(db, watched.user_id, media_item)
-        await ensure_show_watchlist_item(
+        _, show_status_evaluated = await ensure_show_watchlist_item(
             db,
             watched.user_id,
             media_item,
             watched_at=watched.watched_at,
         )
-    if media_item:
+    # A newly created/restored show watchlist item was already evaluated by
+    # ensure_show_watchlist_item; running check_and_update_watchlist on it
+    # would evaluate the same status a second time.
+    if media_item and not show_status_evaluated:
         await check_and_update_watchlist(
             db,
             watched.user_id,

--- a/backend/src/librarysync/core/watchlist.py
+++ b/backend/src/librarysync/core/watchlist.py
@@ -4,6 +4,7 @@ from datetime import date, datetime, timezone
 from typing import Any
 
 from sqlalchemy import and_, case, func, or_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from librarysync.connectors.metadata.base import EpisodeMetadataProvider
@@ -439,6 +440,42 @@ async def _acquire_rate_limit(
     return True
 
 
+WATCHLIST_ITEM_UNIQUE_CONSTRAINT = "uq_watchlist_items_user_media"
+
+
+def _is_watchlist_item_unique_violation(exc: IntegrityError) -> bool:
+    diag = getattr(exc.orig, "diag", None)
+    constraint_name = getattr(diag, "constraint_name", None)
+    if constraint_name:
+        return constraint_name == WATCHLIST_ITEM_UNIQUE_CONSTRAINT
+    return WATCHLIST_ITEM_UNIQUE_CONSTRAINT in str(exc)
+
+
+async def _get_watchlist_item(
+    db: AsyncSession,
+    user_id: str,
+    media_item_id: str,
+) -> WatchlistItem | None:
+    result = await db.execute(
+        select(WatchlistItem).where(
+            WatchlistItem.user_id == user_id,
+            WatchlistItem.media_item_id == media_item_id,
+        )
+    )
+    return result.scalars().first()
+
+
+async def _enqueue_watchlist_sync(
+    db: AsyncSession,
+    watchlist_item: WatchlistItem,
+    media_item: MediaItem | None,
+) -> None:
+    # Deferred import: watchlist_sync depends on watch_pipeline, which imports this module.
+    from librarysync.core.watchlist_sync import enqueue_personal_watchlist_sync
+
+    await enqueue_personal_watchlist_sync(db, watchlist_item, media_item)
+
+
 async def check_and_update_watchlist(
     db: AsyncSession,
     user_id: str,
@@ -490,19 +527,20 @@ async def ensure_show_watchlist_item(
     media_item: MediaItem | None,
     *,
     watched_at: datetime,
-) -> WatchlistItem | None:
-    if not media_item or media_item.media_type not in {"tv", "anime"}:
-        return None
+) -> tuple[WatchlistItem | None, bool]:
+    """
+    Ensure a watchlist item exists for a show.
 
-    existing_result = await db.execute(
-        select(WatchlistItem).where(
-            WatchlistItem.user_id == user_id,
-            WatchlistItem.media_item_id == media_item.id,
-        )
-    )
-    existing_item = existing_result.scalars().first()
+    Returns the item (or None) and a flag telling the caller whether the item
+    was newly created (or restored) and its show status was already evaluated
+    by this call, so the caller can skip a redundant evaluation.
+    """
+    if not media_item or media_item.media_type not in {"tv", "anime"}:
+        return None, False
+
+    existing_item = await _get_watchlist_item(db, user_id, media_item.id)
     if existing_item:
-        return existing_item
+        return existing_item, False
 
     media_ids = normalize_media_ids(
         {
@@ -516,7 +554,7 @@ async def ensure_show_watchlist_item(
         }
     )
     if media_ids:
-        watchlist_item, _ = await upsert_watchlist_item(
+        watchlist_item, upsert_status = await upsert_watchlist_item(
             db,
             user_id,
             media_item.media_type,
@@ -527,8 +565,10 @@ async def ensure_show_watchlist_item(
             "auto_from_history",
             now=watched_at,
             event_raw={},
+            enqueue_sync=True,
         )
-        return watchlist_item
+        evaluated = upsert_status in {"created", "restored"}
+        return watchlist_item, evaluated
 
     initial_status = "added"
     if _is_future_date(media_item.first_air_date, watched_at.date()):
@@ -541,17 +581,34 @@ async def ensure_show_watchlist_item(
         status=initial_status,
         source="auto_from_history",
     )
-    db.add(watchlist_item)
-    await log_watchlist_event(
-        db,
-        user_id,
-        media_item.id,
-        "watchlist_added",
-        {"source": "auto_from_history"},
-    )
-    await db.flush()
+    try:
+        async with db.begin_nested():
+            db.add(watchlist_item)
+            await log_watchlist_event(
+                db,
+                user_id,
+                media_item.id,
+                "watchlist_added",
+                {"source": "auto_from_history"},
+            )
+            await db.flush()
+    except IntegrityError as exc:
+        if not _is_watchlist_item_unique_violation(exc):
+            raise
+        # Lost an insert race with a concurrent job: reuse the row it inserted.
+        existing_item = await _get_watchlist_item(db, user_id, media_item.id)
+        if existing_item is None:
+            raise
+        logger.info(
+            "Watchlist item insert race for user %s media %s; using existing row",
+            user_id,
+            media_item.id,
+        )
+        return existing_item, False
+
     await evaluate_show_watchlist_status(db, user_id, watchlist_item, media_item)
-    return watchlist_item
+    await _enqueue_watchlist_sync(db, watchlist_item, media_item)
+    return watchlist_item, True
 
 
 async def refresh_watchlist_from_history(
@@ -842,6 +899,58 @@ def apply_media_id_update(item: MediaItem, field: str, value: str | None) -> Non
         setattr(item, field, value)
 
 
+async def _resolve_existing_watchlist_item(
+    db: AsyncSession,
+    existing: WatchlistItem,
+    *,
+    user_id: str,
+    media_item: MediaItem,
+    media_type: str,
+    source: str,
+    now: datetime,
+    event_raw: dict[str, Any] | None,
+    enqueue_sync: bool = False,
+) -> tuple[WatchlistItem, str]:
+    if existing.status == "removed":
+        initial_status = "added"
+        now_date = now.date()
+        if media_type == "movie":
+            w_result = await db.execute(
+                select(WatchedItem)
+                .where(
+                    WatchedItem.user_id == user_id,
+                    WatchedItem.media_item_id == media_item.id,
+                )
+                .limit(1)
+            )
+            has_watched = bool(w_result.scalars().first())
+            initial_status = determine_movie_watchlist_status(
+                media_item,
+                has_watched=has_watched,
+                now_date=now_date,
+            )
+        elif media_type in {"tv", "anime"}:
+            if _is_future_date(media_item.first_air_date, now_date):
+                initial_status = "not_released"
+        existing.status = initial_status
+        existing.updated_at = now
+        if existing.source != source and existing.source != "manual":
+            existing.source = source
+        await log_watchlist_event(
+            db,
+            user_id,
+            media_item.id,
+            "watchlist_added",
+            {"restored": True, "source": source, **(event_raw or {})},
+        )
+        if media_type in {"tv", "anime"}:
+            await evaluate_show_watchlist_status(db, user_id, existing, media_item)
+        if enqueue_sync:
+            await _enqueue_watchlist_sync(db, existing, media_item)
+        return existing, "restored"
+    return existing, "already_exists"
+
+
 async def upsert_watchlist_item(
     db: AsyncSession,
     user_id: str,
@@ -854,7 +963,16 @@ async def upsert_watchlist_item(
     *,
     now: datetime | None = None,
     event_raw: dict[str, Any] | None = None,
+    enqueue_sync: bool = False,
 ) -> tuple[WatchlistItem | None, str]:
+    """
+    Create, restore, or return a watchlist item.
+
+    When enqueue_sync is True, a newly created or restored item is also pushed
+    to connected providers via the watchlist outbox. Callers that enqueue the
+    push themselves (manual API add) or that must not echo items back out
+    (watchlist imports) leave this False.
+    """
     normalized_ids = normalize_media_ids(ids)
     if not normalized_ids:
         return None, "skipped"
@@ -904,50 +1022,19 @@ async def upsert_watchlist_item(
                 existing_raw["letterboxd_film_id"] = normalized_ids["letterboxd_film_id"]
                 media_item.raw = existing_raw
 
-    result = await db.execute(
-        select(WatchlistItem).where(
-            WatchlistItem.user_id == user_id,
-            WatchlistItem.media_item_id == media_item.id,
-        )
-    )
-    existing = result.scalars().first()
+    existing = await _get_watchlist_item(db, user_id, media_item.id)
     if existing:
-        if existing.status == "removed":
-            initial_status = "added"
-            now_date = now.date()
-            if media_type == "movie":
-                w_result = await db.execute(
-                    select(WatchedItem)
-                    .where(
-                        WatchedItem.user_id == user_id,
-                        WatchedItem.media_item_id == media_item.id,
-                    )
-                    .limit(1)
-                )
-                has_watched = bool(w_result.scalars().first())
-                initial_status = determine_movie_watchlist_status(
-                    media_item,
-                    has_watched=has_watched,
-                    now_date=now_date,
-                )
-            elif media_type in {"tv", "anime"}:
-                if _is_future_date(media_item.first_air_date, now_date):
-                    initial_status = "not_released"
-            existing.status = initial_status
-            existing.updated_at = now
-            if existing.source != source and existing.source != "manual":
-                existing.source = source
-            await log_watchlist_event(
-                db,
-                user_id,
-                media_item.id,
-                "watchlist_added",
-                {"restored": True, "source": source, **(event_raw or {})},
-            )
-            if media_type in {"tv", "anime"}:
-                await evaluate_show_watchlist_status(db, user_id, existing, media_item)
-            return existing, "restored"
-        return existing, "already_exists"
+        return await _resolve_existing_watchlist_item(
+            db,
+            existing,
+            user_id=user_id,
+            media_item=media_item,
+            media_type=media_type,
+            source=source,
+            now=now,
+            event_raw=event_raw,
+            enqueue_sync=enqueue_sync,
+        )
 
     initial_status = "added"
     if media_type == "movie":
@@ -976,17 +1063,45 @@ async def upsert_watchlist_item(
         status=initial_status,
         source=source,
     )
-    db.add(watchlist_item)
-    await log_watchlist_event(
-        db,
-        user_id,
-        media_item.id,
-        "watchlist_added",
-        {"source": source, **(event_raw or {})},
-    )
-    await db.flush()
+    try:
+        async with db.begin_nested():
+            db.add(watchlist_item)
+            await log_watchlist_event(
+                db,
+                user_id,
+                media_item.id,
+                "watchlist_added",
+                {"source": source, **(event_raw or {})},
+            )
+            await db.flush()
+    except IntegrityError as exc:
+        if not _is_watchlist_item_unique_violation(exc):
+            raise
+        # Lost an insert race with a concurrent writer: reuse the row it inserted.
+        existing = await _get_watchlist_item(db, user_id, media_item.id)
+        if existing is None:
+            raise
+        logger.info(
+            "Watchlist item insert race for user %s media %s; using existing row",
+            user_id,
+            media_item.id,
+        )
+        # The concurrent writer owns the sync push for the row it inserted.
+        return await _resolve_existing_watchlist_item(
+            db,
+            existing,
+            user_id=user_id,
+            media_item=media_item,
+            media_type=media_type,
+            source=source,
+            now=now,
+            event_raw=event_raw,
+            enqueue_sync=False,
+        )
     if media_type in {"tv", "anime"}:
         await evaluate_show_watchlist_status(db, user_id, watchlist_item, media_item)
+    if enqueue_sync:
+        await _enqueue_watchlist_sync(db, watchlist_item, media_item)
     return watchlist_item, "created"
 
 

--- a/backend/src/librarysync/core/watchlist.py
+++ b/backend/src/librarysync/core/watchlist.py
@@ -480,8 +480,78 @@ async def check_and_update_watchlist(
             reason="watched",
         )
 
-    elif media_item.media_type == "tv":
+    elif media_item.media_type in {"tv", "anime"}:
         await evaluate_show_watchlist_status(db, user_id, item, media_item)
+
+
+async def ensure_show_watchlist_item(
+    db: AsyncSession,
+    user_id: str,
+    media_item: MediaItem | None,
+    *,
+    watched_at: datetime,
+) -> WatchlistItem | None:
+    if not media_item or media_item.media_type not in {"tv", "anime"}:
+        return None
+
+    existing_result = await db.execute(
+        select(WatchlistItem).where(
+            WatchlistItem.user_id == user_id,
+            WatchlistItem.media_item_id == media_item.id,
+        )
+    )
+    existing_item = existing_result.scalars().first()
+    if existing_item:
+        return existing_item
+
+    media_ids = normalize_media_ids(
+        {
+            "imdb_id": media_item.imdb_id,
+            "tmdb_id": media_item.tmdb_id,
+            "tvdb_id": media_item.tvdb_id,
+            "tvmaze_id": media_item.tvmaze_id,
+            "kitsu_id": media_item.kitsu_id,
+            "myanimelist_id": media_item.myanimelist_id,
+            "anilist_id": media_item.anilist_id,
+        }
+    )
+    if media_ids:
+        watchlist_item, _ = await upsert_watchlist_item(
+            db,
+            user_id,
+            media_item.media_type,
+            media_ids,
+            media_item.title,
+            media_item.year,
+            media_item.poster_url,
+            "auto_from_history",
+            now=watched_at,
+            event_raw={},
+        )
+        return watchlist_item
+
+    initial_status = "added"
+    if _is_future_date(media_item.first_air_date, watched_at.date()):
+        initial_status = "not_released"
+
+    watchlist_item = WatchlistItem(
+        user_id=user_id,
+        media_item_id=media_item.id,
+        type=media_item.media_type,
+        status=initial_status,
+        source="auto_from_history",
+    )
+    db.add(watchlist_item)
+    await log_watchlist_event(
+        db,
+        user_id,
+        media_item.id,
+        "watchlist_added",
+        {"source": "auto_from_history"},
+    )
+    await db.flush()
+    await evaluate_show_watchlist_status(db, user_id, watchlist_item, media_item)
+    return watchlist_item
 
 
 async def refresh_watchlist_from_history(
@@ -527,7 +597,7 @@ async def refresh_watchlist_from_history(
             new_status,
             reason="history_update",
         )
-    elif media_item.media_type == "tv":
+    elif media_item.media_type in {"tv", "anime"}:
         await evaluate_show_watchlist_status(db, user_id, item, media_item)
 
 
@@ -860,7 +930,7 @@ async def upsert_watchlist_item(
                     has_watched=has_watched,
                     now_date=now_date,
                 )
-            elif media_type == "tv":
+            elif media_type in {"tv", "anime"}:
                 if _is_future_date(media_item.first_air_date, now_date):
                     initial_status = "not_released"
             existing.status = initial_status
@@ -874,7 +944,7 @@ async def upsert_watchlist_item(
                 "watchlist_added",
                 {"restored": True, "source": source, **(event_raw or {})},
             )
-            if media_type == "tv":
+            if media_type in {"tv", "anime"}:
                 await evaluate_show_watchlist_status(db, user_id, existing, media_item)
             return existing, "restored"
         return existing, "already_exists"
@@ -895,7 +965,7 @@ async def upsert_watchlist_item(
             has_watched=has_watched,
             now_date=now.date(),
         )
-    elif media_type == "tv":
+    elif media_type in {"tv", "anime"}:
         if _is_future_date(media_item.first_air_date, now.date()):
             initial_status = "not_released"
 
@@ -915,7 +985,7 @@ async def upsert_watchlist_item(
         {"source": source, **(event_raw or {})},
     )
     await db.flush()
-    if media_type == "tv":
+    if media_type in {"tv", "anime"}:
         await evaluate_show_watchlist_status(db, user_id, watchlist_item, media_item)
     return watchlist_item, "created"
 

--- a/backend/src/librarysync/db/migrations/versions/b3d4e5f6a7b8_backfill_watchlist_from_show_history.py
+++ b/backend/src/librarysync/db/migrations/versions/b3d4e5f6a7b8_backfill_watchlist_from_show_history.py
@@ -40,7 +40,7 @@ FROM (
     JOIN episode_items e ON e.id = w.episode_item_id
     JOIN media_items m ON m.id = e.show_media_item_id
     WHERE m.media_type IN ('tv', 'anime')
-)
+) show_history
 """
 )
 
@@ -74,17 +74,200 @@ ON CONFLICT (user_id, media_item_id) DO NOTHING
 """
 )
 
-_DELETE_WATCHLIST_ITEM = sa.text(
-    """
-DELETE FROM watchlist_items
-WHERE source = 'auto_from_history'
-  AND id = :id
-"""
+# Mirrors _base_watchlist_payload in core/watchlist_sync.py (null ids included).
+_BASE_WATCHLIST_PAYLOAD_JSONB = """jsonb_build_object(
+        'watchlist_item_id', wi.id,
+        'media_item_id', m.id,
+        'media_type', wi.type,
+        'imdb_id', m.imdb_id,
+        'tmdb_id', m.tmdb_id,
+        'tvdb_id', m.tvdb_id
+    )"""
+
+# Mirrors collect_external_ids in core/watch_pipeline.py: keys imdb/tmdb/tvdb,
+# imdb lowercased, each key present only when the source value is non-empty.
+_EXTERNAL_IDS_JSONB = """(
+        CASE WHEN NULLIF(m.imdb_id, '') IS NOT NULL
+            THEN jsonb_build_object('imdb', lower(m.imdb_id))
+            ELSE jsonb_build_object()
+        END
+        || CASE WHEN NULLIF(m.tmdb_id, '') IS NOT NULL
+            THEN jsonb_build_object('tmdb', m.tmdb_id)
+            ELSE jsonb_build_object()
+        END
+        || CASE WHEN NULLIF(m.tvdb_id, '') IS NOT NULL
+            THEN jsonb_build_object('tvdb', m.tvdb_id)
+            ELSE jsonb_build_object()
+        END
+    )"""
+
+# movie_ids for watchlist types movie/anime, show_ids otherwise (payload builders).
+_EXTERNAL_IDS_BY_TYPE_JSONB = (
+    "CASE WHEN wi.type IN ('movie', 'anime') "
+    f"THEN jsonb_build_object('movie_ids', {_EXTERNAL_IDS_JSONB}) "
+    f"ELSE jsonb_build_object('show_ids', {_EXTERNAL_IDS_JSONB}) "
+    "END"
 )
+
+# Builders return None when no external id is available: skip enqueueing then.
+_HAS_EXTERNAL_IDS = """(
+        NULLIF(m.imdb_id, '') IS NOT NULL
+        OR NULLIF(m.tmdb_id, '') IS NOT NULL
+        OR NULLIF(m.tvdb_id, '') IS NOT NULL
+    )"""
+
+_SIMKL_ID_JSON = "m.raw->>'simkl_id'"
+_SIMKL_IDS_JSONB = (
+    f"{_EXTERNAL_IDS_JSONB} || CASE WHEN NULLIF({_SIMKL_ID_JSON}, '') IS NOT NULL "
+    f"THEN jsonb_build_object('simkl', {_SIMKL_ID_JSON}) ELSE jsonb_build_object() END"
+)
+_SIMKL_PAYLOAD_JSONB = (
+    f"{_BASE_WATCHLIST_PAYLOAD_JSONB} "
+    f"|| jsonb_build_object('simkl_id', {_SIMKL_ID_JSON}) "
+    f"|| CASE WHEN wi.type IN ('movie', 'anime') "
+    f"THEN jsonb_build_object('movie_ids', {_SIMKL_IDS_JSONB}) "
+    f"ELSE jsonb_build_object('show_ids', {_SIMKL_IDS_JSONB}) "
+    "END"
+)
+
+_LETTERBOXD_FILM_ID_JSON = "m.raw->>'letterboxd_film_id'"
+_LETTERBOXD_PAYLOAD_JSONB = (
+    f"{_BASE_WATCHLIST_PAYLOAD_JSONB} "
+    f"|| jsonb_build_object('letterboxd_film_id', {_LETTERBOXD_FILM_ID_JSON})"
+)
+
+_PUBLICMETADB_PAYLOAD_JSONB = (
+    f"{_BASE_WATCHLIST_PAYLOAD_JSONB} "
+    "|| jsonb_build_object("
+    "'tmdb_id', m.tmdb_id, "
+    "'media_type', CASE WHEN wi.type = 'tv' THEN 'tv' ELSE 'movie' END"
+    ")"
+)
+
+_CONFIG_JSONB = "CAST(i.config AS jsonb)"
+
+
+def _jsonb_truthy(expr: str) -> str:
+    """Replicates _coerce_enabled in core/publicmetadb.py for a jsonb value."""
+    return f"""CASE
+        WHEN jsonb_typeof({expr}) = 'boolean' THEN {expr} = CAST('true' AS jsonb)
+        WHEN jsonb_typeof({expr}) = 'number' THEN CAST(CAST({expr} AS text) AS numeric) <> 0
+        WHEN jsonb_typeof({expr}) = 'string'
+            THEN lower(btrim(btrim(CAST({expr} AS text), '"'))) IN ('1', 'true', 'yes', 'on')
+        ELSE false
+    END"""
+
+
+# Replicates is_publicmetadb_sync_enabled against integrations.config:
+# sync_enabled, else legacy enabled, else metadata_enabled, else False.
+_PUBLICMETADB_SYNC_ENABLED = f"""CASE
+        WHEN i.config IS NULL OR jsonb_typeof({_CONFIG_JSONB}) <> 'object' THEN false
+        WHEN {_CONFIG_JSONB} ? 'sync_enabled' THEN {_jsonb_truthy(f"{_CONFIG_JSONB} -> 'sync_enabled'")}
+        WHEN {_CONFIG_JSONB} ? 'enabled' THEN {_jsonb_truthy(f"{_CONFIG_JSONB} -> 'enabled'")}
+        WHEN {_CONFIG_JSONB} ? 'metadata_enabled'
+            THEN {_jsonb_truthy(f"{_CONFIG_JSONB} -> 'metadata_enabled'")}
+        ELSE false
+    END"""
+
+# Mirrors _enqueue_watchlist_job in core/watchlist_sync.py: connected integration
+# (status != 'disconnected') with stored secrets, personal watchlist source not
+# disabled (missing row = runtime default enabled). wi.status != 'removed' keeps
+# pre-existing user-removed items from being re-added at providers. Payload and
+# per-provider guards mirror the payload builders exactly.
+_OUTBOX_PUSH_INSERT_TEMPLATE = """INSERT INTO outbox (
+    id,
+    user_id,
+    target_provider,
+    job_type,
+    payload,
+    status,
+    run_after,
+    attempts,
+    last_error,
+    dedupe_key,
+    created_at,
+    updated_at
+)
+SELECT
+    :id,
+    wi.user_id,
+    '{provider}',
+    'push_watchlist',
+    CAST(
+        {payload}
+    AS json),
+    'pending',
+    NULL,
+    0,
+    NULL,
+    wi.user_id || ':{provider}:push_watchlist:' || wi.id,
+    :now,
+    :now
+FROM watchlist_items wi
+JOIN media_items m ON m.id = wi.media_item_id
+JOIN integrations i
+    ON i.user_id = wi.user_id
+    AND i.provider = '{provider}'
+    AND i.status != 'disconnected'
+JOIN integration_secrets s ON s.integration_id = i.id
+LEFT JOIN watchlist_sources ws
+    ON ws.user_id = wi.user_id
+    AND ws.provider = '{provider}'
+    AND ws.source_type = 'personal'
+    AND ws.external_id = 'watchlist'
+WHERE wi.user_id = :user_id
+    AND wi.media_item_id = :media_item_id
+    AND wi.status != 'removed'
+    AND COALESCE(ws.is_enabled, true)
+    AND {guard}
+ON CONFLICT (dedupe_key) DO NOTHING
+"""
+
+
+def _build_outbox_push_insert(provider: str, payload: str, guard: str) -> sa.TextClause:
+    return sa.text(
+        _OUTBOX_PUSH_INSERT_TEMPLATE.format(provider=provider, payload=payload, guard=guard)
+    )
+
+
+_OUTBOX_PUSH_INSERTS = {
+    "trakt": _build_outbox_push_insert(
+        "trakt",
+        f"{_BASE_WATCHLIST_PAYLOAD_JSONB} || {_EXTERNAL_IDS_BY_TYPE_JSONB}",
+        _HAS_EXTERNAL_IDS,
+    ),
+    "simkl": _build_outbox_push_insert(
+        "simkl",
+        _SIMKL_PAYLOAD_JSONB,
+        f"({_HAS_EXTERNAL_IDS} OR NULLIF({_SIMKL_ID_JSON}, '') IS NOT NULL)",
+    ),
+    "letterboxd": _build_outbox_push_insert(
+        "letterboxd",
+        _LETTERBOXD_PAYLOAD_JSONB,
+        "wi.type IN ('movie', 'anime') AND ("
+        "NULLIF(m.imdb_id, '') IS NOT NULL "
+        "OR NULLIF(m.tmdb_id, '') IS NOT NULL "
+        f"OR NULLIF({_LETTERBOXD_FILM_ID_JSON}, '') IS NOT NULL)",
+    ),
+    "publicmetadb": _build_outbox_push_insert(
+        "publicmetadb",
+        _PUBLICMETADB_PAYLOAD_JSONB,
+        f"NULLIF(m.tmdb_id, '') IS NOT NULL AND ({_PUBLICMETADB_SYNC_ENABLED})",
+    ),
+}
 
 
 def _migration_id(user_id: str, media_item_id: str) -> str:
     return str(uuid5(NAMESPACE_URL, f"librarysync:auto_from_history:{user_id}:{media_item_id}"))
+
+
+def _migration_push_id(user_id: str, media_item_id: str, provider: str) -> str:
+    return str(
+        uuid5(
+            NAMESPACE_URL,
+            f"librarysync:auto_from_history_push:{user_id}:{media_item_id}:{provider}",
+        )
+    )
 
 
 def _history_rows(bind) -> list[dict[str, str]]:
@@ -107,11 +290,26 @@ def upgrade() -> None:
         return
     now = datetime.now(timezone.utc)
     bind.execute(_INSERT_WATCHLIST_ITEM, [{**row, "now": now} for row in rows])
+    # Push every history-derived watchlist item to connected providers, mirroring
+    # enqueue_personal_watchlist_sync. The dedupe-key conflict clause skips rows
+    # whose push was already enqueued at runtime (e.g. manual adds).
+    for provider, statement in _OUTBOX_PUSH_INSERTS.items():
+        bind.execute(
+            statement,
+            [
+                {
+                    "id": _migration_push_id(row["user_id"], row["media_item_id"], provider),
+                    "user_id": row["user_id"],
+                    "media_item_id": row["media_item_id"],
+                    "now": now,
+                }
+                for row in rows
+            ],
+        )
 
 
 def downgrade() -> None:
-    bind = op.get_bind()
-    rows = _history_rows(bind)
-    if not rows:
-        return
-    bind.execute(_DELETE_WATCHLIST_ITEM, [{"id": row["id"]} for row in rows])
+    # Intentionally a no-op: watchlist rows are user data once created. Rows
+    # backfilled by upgrade() stay in place on downgrade, regardless of
+    # whether they came from this migration, manual adds, or provider syncs.
+    pass

--- a/backend/src/librarysync/db/migrations/versions/b3d4e5f6a7b8_backfill_watchlist_from_show_history.py
+++ b/backend/src/librarysync/db/migrations/versions/b3d4e5f6a7b8_backfill_watchlist_from_show_history.py
@@ -1,0 +1,117 @@
+"""backfill watchlist from show history
+
+Revision ID: b3d4e5f6a7b8
+Revises: e4f6a8b1c2d3
+Create Date: 2026-07-18 12:00:00.000000
+
+"""
+
+from datetime import datetime, timezone
+from uuid import NAMESPACE_URL, uuid5
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b3d4e5f6a7b8"
+down_revision = "e4f6a8b1c2d3"
+branch_labels = None
+depends_on = None
+
+
+_SHOW_HISTORY_SELECT = sa.text(
+    """
+SELECT DISTINCT user_id, media_item_id, media_type
+FROM (
+    SELECT
+        w.user_id,
+        m.id AS media_item_id,
+        m.media_type AS media_type
+    FROM watched_items w
+    JOIN media_items m ON m.id = w.media_item_id
+    WHERE m.media_type IN ('tv', 'anime')
+
+    UNION
+
+    SELECT
+        w.user_id,
+        e.show_media_item_id AS media_item_id,
+        m.media_type AS media_type
+    FROM watched_items w
+    JOIN episode_items e ON e.id = w.episode_item_id
+    JOIN media_items m ON m.id = e.show_media_item_id
+    WHERE m.media_type IN ('tv', 'anime')
+)
+"""
+)
+
+_INSERT_WATCHLIST_ITEM = sa.text(
+    """
+INSERT INTO watchlist_items (
+    id,
+    user_id,
+    media_item_id,
+    type,
+    status,
+    source,
+    rewatch_requested,
+    rewatch_requested_at,
+    created_at,
+    updated_at
+)
+VALUES (
+    :id,
+    :user_id,
+    :media_item_id,
+    :media_type,
+    'added',
+    'auto_from_history',
+    false,
+    NULL,
+    :now,
+    :now
+)
+ON CONFLICT (user_id, media_item_id) DO NOTHING
+"""
+)
+
+_DELETE_WATCHLIST_ITEM = sa.text(
+    """
+DELETE FROM watchlist_items
+WHERE source = 'auto_from_history'
+  AND id = :id
+"""
+)
+
+
+def _migration_id(user_id: str, media_item_id: str) -> str:
+    return str(uuid5(NAMESPACE_URL, f"librarysync:auto_from_history:{user_id}:{media_item_id}"))
+
+
+def _history_rows(bind) -> list[dict[str, str]]:
+    rows = bind.execute(_SHOW_HISTORY_SELECT).mappings().all()
+    return [
+        {
+            "id": _migration_id(row["user_id"], row["media_item_id"]),
+            "user_id": row["user_id"],
+            "media_item_id": row["media_item_id"],
+            "media_type": row["media_type"],
+        }
+        for row in rows
+    ]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    rows = _history_rows(bind)
+    if not rows:
+        return
+    now = datetime.now(timezone.utc)
+    bind.execute(_INSERT_WATCHLIST_ITEM, [{**row, "now": now} for row in rows])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    rows = _history_rows(bind)
+    if not rows:
+        return
+    bind.execute(_DELETE_WATCHLIST_ITEM, [{"id": row["id"]} for row in rows])

--- a/backend/src/librarysync/jobs/watchlist_refresh.py
+++ b/backend/src/librarysync/jobs/watchlist_refresh.py
@@ -73,7 +73,7 @@ async def run_watchlist_refresh(db: AsyncSession, job: ScheduledJob) -> None:
         for item, media in rows:
             if media.media_type == "movie":
                 await _refresh_movie_status(db, user_id, item, media)
-            elif media.media_type == "tv":
+            elif media.media_type in {"tv", "anime"}:
                 await evaluate_show_watchlist_status(db, user_id, item, media)
         await extend_scheduled_job(db, job, WATCHLIST_REFRESH_LEASE)
 
@@ -136,7 +136,7 @@ async def _load_watchlist_rows_for_refresh(
         .where(
             WatchlistItem.user_id == user_id,
             WatchlistItem.status.in_(WATCHLIST_REFRESH_STATUSES),
-            MediaItem.media_type == "tv",
+            MediaItem.media_type.in_(["tv", "anime"]),
             EpisodeItem.updated_at.is_not(None),
             EpisodeItem.updated_at > last_run_at,
         )
@@ -151,7 +151,7 @@ async def _load_watchlist_rows_for_refresh(
         .where(
             WatchlistItem.user_id == user_id,
             WatchlistItem.status.in_(WATCHLIST_REFRESH_STATUSES),
-            MediaItem.media_type == "tv",
+            MediaItem.media_type.in_(["tv", "anime"]),
             EpisodeItem.air_date.is_not(None),
             EpisodeItem.air_date >= last_run_date,
             EpisodeItem.air_date <= now_date,
@@ -197,7 +197,7 @@ async def _load_watchlist_rows_for_refresh(
         .where(
             WatchlistItem.user_id == user_id,
             WatchlistItem.status.in_(WATCHLIST_REFRESH_STATUSES),
-            MediaItem.media_type == "tv",
+            MediaItem.media_type.in_(["tv", "anime"]),
             ~exists(
                 select(EpisodeItem.id).where(
                     EpisodeItem.show_media_item_id == MediaItem.id
@@ -220,7 +220,7 @@ async def _backfill_missing_show_episodes(
     rows: list[tuple[WatchlistItem, MediaItem]],
 ) -> None:
     media_by_id = {
-        media.id: media for item, media in rows if media.media_type == "tv"
+        media.id: media for item, media in rows if media.media_type in {"tv", "anime"}
     }
     if not media_by_id:
         return

--- a/backend/tests/test_migration_backfill_watchlist_from_history.py
+++ b/backend/tests/test_migration_backfill_watchlist_from_history.py
@@ -1,0 +1,82 @@
+from unittest.mock import patch
+
+from librarysync.db.migrations.versions import b3d4e5f6a7b8_backfill_watchlist_from_show_history as migration
+
+
+class _FakeMappings:
+    def __init__(self, rows: list[dict[str, str]]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[dict[str, str]]:
+        return self._rows
+
+
+class _FakeResult:
+    def __init__(self, rows: list[dict[str, str]]) -> None:
+        self._rows = rows
+
+    def mappings(self) -> _FakeMappings:
+        return _FakeMappings(self._rows)
+
+
+class _FakeBind:
+    def __init__(self, rows: list[dict[str, str]]) -> None:
+        self.rows = rows
+        self.calls: list[tuple[str, object]] = []
+
+    def execute(self, statement, parameters=None):
+        self.calls.append((str(statement), parameters))
+        if "FROM watched_items" in str(statement):
+            return _FakeResult(self.rows)
+        return None
+
+
+def test_upgrade_inserts_auto_from_history_watchlist_rows() -> None:
+    bind = _FakeBind(
+        [
+            {
+                "user_id": "user-1",
+                "media_item_id": "show-1",
+                "media_type": "tv",
+            }
+        ]
+    )
+
+    with patch.object(migration.op, "get_bind", return_value=bind):
+        migration.upgrade()
+
+    select_sql, select_params = bind.calls[0]
+    insert_sql, insert_params = bind.calls[1]
+    assert select_params is None
+    assert "JOIN episode_items" in select_sql
+    assert "m.media_type IN ('tv', 'anime')" in select_sql
+    assert "INSERT INTO watchlist_items" in insert_sql
+    assert "'auto_from_history'" in insert_sql
+    assert "ON CONFLICT (user_id, media_item_id) DO NOTHING" in insert_sql
+    assert isinstance(insert_params, list)
+    assert insert_params[0]["id"] == migration._migration_id("user-1", "show-1")
+    assert insert_params[0]["user_id"] == "user-1"
+    assert insert_params[0]["media_item_id"] == "show-1"
+    assert insert_params[0]["media_type"] == "tv"
+    assert "now" in insert_params[0]
+
+
+def test_downgrade_deletes_only_migration_backfilled_rows() -> None:
+    bind = _FakeBind(
+        [
+            {
+                "user_id": "user-1",
+                "media_item_id": "show-1",
+                "media_type": "tv",
+            }
+        ]
+    )
+
+    with patch.object(migration.op, "get_bind", return_value=bind):
+        migration.downgrade()
+
+    delete_sql, delete_params = bind.calls[1]
+    assert "DELETE FROM watchlist_items" in delete_sql
+    assert "source = 'auto_from_history'" in delete_sql
+    assert "id = :id" in delete_sql
+    assert delete_params == [{"id": migration._migration_id("user-1", "show-1")}]

--- a/backend/tests/test_migration_backfill_watchlist_from_history.py
+++ b/backend/tests/test_migration_backfill_watchlist_from_history.py
@@ -61,7 +61,107 @@ def test_upgrade_inserts_auto_from_history_watchlist_rows() -> None:
     assert "now" in insert_params[0]
 
 
-def test_downgrade_deletes_only_migration_backfilled_rows() -> None:
+_PROVIDERS = ["trakt", "simkl", "letterboxd", "publicmetadb"]
+
+
+def _run_upgrade_with_one_row() -> _FakeBind:
+    bind = _FakeBind(
+        [
+            {
+                "user_id": "user-1",
+                "media_item_id": "show-1",
+                "media_type": "tv",
+            }
+        ]
+    )
+    with patch.object(migration.op, "get_bind", return_value=bind):
+        migration.upgrade()
+    return bind
+
+
+def test_upgrade_enqueues_push_watchlist_outbox_jobs_per_provider() -> None:
+    bind = _run_upgrade_with_one_row()
+
+    outbox_calls = bind.calls[2:]
+    assert len(outbox_calls) == len(_PROVIDERS)
+    for (sql, params), provider in zip(outbox_calls, _PROVIDERS):
+        assert "INSERT INTO outbox" in sql
+        assert "'push_watchlist'" in sql
+        assert f"'{provider}'" in sql
+        assert "ON CONFLICT (dedupe_key) DO NOTHING" in sql
+        assert f"wi.user_id || ':{provider}:push_watchlist:' || wi.id" in sql
+        assert isinstance(params, list)
+        assert len(params) == 1
+        assert params[0]["id"] == migration._migration_push_id("user-1", "show-1", provider)
+        assert params[0]["user_id"] == "user-1"
+        assert params[0]["media_item_id"] == "show-1"
+        assert "now" in params[0]
+
+
+def test_outbox_insert_mirrors_runtime_provider_gating() -> None:
+    bind = _run_upgrade_with_one_row()
+
+    for sql, _params in bind.calls[2:]:
+        # Connected integration with secrets (mirrors _enqueue_watchlist_job).
+        assert "JOIN integrations i" in sql
+        assert "i.status != 'disconnected'" in sql
+        assert "JOIN integration_secrets s ON s.integration_id = i.id" in sql
+        # Personal watchlist source not disabled (missing row = enabled).
+        assert "ws.source_type = 'personal'" in sql
+        assert "ws.external_id = 'watchlist'" in sql
+        assert "COALESCE(ws.is_enabled, true)" in sql
+        # Payload identity mirrors _base_watchlist_payload.
+        assert "'watchlist_item_id', wi.id" in sql
+        assert "'media_item_id', m.id" in sql
+        assert "'media_type', wi.type" in sql
+
+
+def test_outbox_payload_guards_mirror_payload_builders() -> None:
+    bind = _run_upgrade_with_one_row()
+    sql_by_provider = {provider: sql for (sql, _), provider in zip(bind.calls[2:], _PROVIDERS)}
+
+    trakt = sql_by_provider["trakt"]
+    # collect_external_ids shape: imdb lowercased, keys only when non-empty.
+    assert "jsonb_build_object('imdb', lower(m.imdb_id))" in trakt
+    assert "jsonb_build_object('tmdb', m.tmdb_id)" in trakt
+    assert "jsonb_build_object('tvdb', m.tvdb_id)" in trakt
+    assert "NULLIF(m.imdb_id, '') IS NOT NULL" in trakt
+    assert "NULLIF(m.tmdb_id, '') IS NOT NULL" in trakt
+    assert "NULLIF(m.tvdb_id, '') IS NOT NULL" in trakt
+    assert "'movie_ids'" in trakt
+    assert "'show_ids'" in trakt
+
+    simkl = sql_by_provider["simkl"]
+    assert "m.raw->>'simkl_id'" in simkl
+    assert "jsonb_build_object('simkl_id', m.raw->>'simkl_id')" in simkl
+    assert "jsonb_build_object('simkl', m.raw->>'simkl_id')" in simkl
+
+    letterboxd = sql_by_provider["letterboxd"]
+    assert "wi.type IN ('movie', 'anime')" in letterboxd
+    assert "m.raw->>'letterboxd_film_id'" in letterboxd
+    assert "NULLIF(m.imdb_id, '') IS NOT NULL" in letterboxd
+    assert "NULLIF(m.tmdb_id, '') IS NOT NULL" in letterboxd
+    assert "NULLIF(m.raw->>'letterboxd_film_id', '') IS NOT NULL" in letterboxd
+
+    publicmetadb = sql_by_provider["publicmetadb"]
+    assert "NULLIF(m.tmdb_id, '') IS NOT NULL" in publicmetadb
+    # is_publicmetadb_sync_enabled config key precedence.
+    assert "? 'sync_enabled'" in publicmetadb
+    assert "? 'metadata_enabled'" in publicmetadb
+    assert "? 'enabled'" in publicmetadb
+    assert "jsonb_typeof" in publicmetadb
+
+
+def test_upgrade_without_history_rows_enqueues_nothing() -> None:
+    bind = _FakeBind([])
+
+    with patch.object(migration.op, "get_bind", return_value=bind):
+        migration.upgrade()
+
+    assert len(bind.calls) == 1  # only the history select
+
+
+def test_downgrade_leaves_watchlist_rows_untouched() -> None:
     bind = _FakeBind(
         [
             {
@@ -75,8 +175,4 @@ def test_downgrade_deletes_only_migration_backfilled_rows() -> None:
     with patch.object(migration.op, "get_bind", return_value=bind):
         migration.downgrade()
 
-    delete_sql, delete_params = bind.calls[1]
-    assert "DELETE FROM watchlist_items" in delete_sql
-    assert "source = 'auto_from_history'" in delete_sql
-    assert "id = :id" in delete_sql
-    assert delete_params == [{"id": migration._migration_id("user-1", "show-1")}]
+    assert bind.calls == []

--- a/backend/tests/test_new_item_episode_metadata.py
+++ b/backend/tests/test_new_item_episode_metadata.py
@@ -86,6 +86,7 @@ class TestProcessNewItemJobEpisodeMetadata(unittest.TestCase):
             patch(
                 "librarysync.core.watch_pipeline.ensure_show_watchlist_item",
                 new_callable=AsyncMock,
+                return_value=(None, False),
             ) as mock_ensure_show,
             patch(
                 "librarysync.core.watch_pipeline.check_and_update_watchlist",
@@ -142,6 +143,7 @@ class TestProcessNewItemJobEpisodeMetadata(unittest.TestCase):
             patch(
                 "librarysync.core.watch_pipeline.ensure_show_watchlist_item",
                 new_callable=AsyncMock,
+                return_value=(None, False),
             ),
             patch(
                 "librarysync.core.watch_pipeline.check_and_update_watchlist",
@@ -191,6 +193,7 @@ class TestProcessNewItemJobEpisodeMetadata(unittest.TestCase):
             patch(
                 "librarysync.core.watch_pipeline.ensure_show_watchlist_item",
                 new_callable=AsyncMock,
+                return_value=(None, False),
             ),
             patch(
                 "librarysync.core.watch_pipeline.check_and_update_watchlist",
@@ -243,6 +246,7 @@ class TestProcessNewItemJobEpisodeMetadata(unittest.TestCase):
             patch(
                 "librarysync.core.watch_pipeline.ensure_show_watchlist_item",
                 new_callable=AsyncMock,
+                return_value=(None, False),
             ),
             patch(
                 "librarysync.core.watch_pipeline.check_and_update_watchlist",

--- a/backend/tests/test_new_item_episode_metadata.py
+++ b/backend/tests/test_new_item_episode_metadata.py
@@ -50,6 +50,61 @@ def _make_job(watched_id: str = "watched-1", is_rewatch: bool = False):
 
 
 class TestProcessNewItemJobEpisodeMetadata(unittest.TestCase):
+    def test_episode_watch_ensures_parent_show_in_watchlist(self) -> None:
+        db = AsyncMock()
+        media_item = _make_media_item(media_type="tv", tmdb_id="12345")
+        episode_item = _make_episode_item(title=None)
+        watched = _make_watched(episode_item_id="episode-1")
+
+        async def fake_db_get(model, pk):
+            if model.__name__ == "WatchedItem":
+                return watched
+            if model.__name__ == "EpisodeItem":
+                return episode_item
+            if model.__name__ == "MediaItem":
+                return media_item
+            return None
+
+        db.get.side_effect = fake_db_get
+        job = _make_job()
+
+        with (
+            patch(
+                "librarysync.core.watch_pipeline.enrich_watched_metadata",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "librarysync.core.watch_pipeline.refresh_episode_metadata",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "librarysync.core.watch_pipeline.backfill_show_episodes",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "librarysync.core.watch_pipeline.ensure_show_watchlist_item",
+                new_callable=AsyncMock,
+            ) as mock_ensure_show,
+            patch(
+                "librarysync.core.watch_pipeline.check_and_update_watchlist",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "librarysync.core.watch_pipeline._sync_to_integrations",
+                new_callable=AsyncMock,
+            ),
+        ):
+            asyncio.run(process_new_item_job(db, job))
+
+        mock_ensure_show.assert_awaited_once_with(
+            db,
+            watched.user_id,
+            media_item,
+            watched_at=watched.watched_at,
+        )
+
     def test_refresh_episode_metadata_called_for_episode_watch(self) -> None:
         """refresh_episode_metadata must be called directly when the watched item is an episode."""
         db = AsyncMock()
@@ -83,6 +138,10 @@ class TestProcessNewItemJobEpisodeMetadata(unittest.TestCase):
                 "librarysync.core.watch_pipeline.backfill_show_episodes",
                 new_callable=AsyncMock,
                 return_value=False,
+            ),
+            patch(
+                "librarysync.core.watch_pipeline.ensure_show_watchlist_item",
+                new_callable=AsyncMock,
             ),
             patch(
                 "librarysync.core.watch_pipeline.check_and_update_watchlist",
@@ -128,6 +187,10 @@ class TestProcessNewItemJobEpisodeMetadata(unittest.TestCase):
                 "librarysync.core.watch_pipeline.backfill_show_episodes",
                 new_callable=AsyncMock,
                 return_value=False,
+            ),
+            patch(
+                "librarysync.core.watch_pipeline.ensure_show_watchlist_item",
+                new_callable=AsyncMock,
             ),
             patch(
                 "librarysync.core.watch_pipeline.check_and_update_watchlist",
@@ -176,6 +239,10 @@ class TestProcessNewItemJobEpisodeMetadata(unittest.TestCase):
                 "librarysync.core.watch_pipeline.backfill_show_episodes",
                 new_callable=AsyncMock,
                 return_value=False,
+            ),
+            patch(
+                "librarysync.core.watch_pipeline.ensure_show_watchlist_item",
+                new_callable=AsyncMock,
             ),
             patch(
                 "librarysync.core.watch_pipeline.check_and_update_watchlist",

--- a/backend/tests/test_watch_pipeline_show_watchlist.py
+++ b/backend/tests/test_watch_pipeline_show_watchlist.py
@@ -1,0 +1,211 @@
+"""Tests for show watchlist handling in process_new_item_job.
+
+Covers:
+- First watch of a show: the watchlist item is created, evaluated exactly once,
+  and pushed to connected providers exactly once (no redundant evaluation via
+  check_and_update_watchlist).
+- Subsequent watches: the pre-existing item is evaluated exactly once via
+  check_and_update_watchlist and not pushed again.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from librarysync.core.watch_pipeline import process_new_item_job
+
+NOW = datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc)
+
+
+class _FakeScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def first(self):
+        return self._value
+
+
+class _FakeResult:
+    def __init__(self, scalar=None):
+        self._scalar = scalar
+
+    def scalars(self):
+        return _FakeScalarResult(self._scalar)
+
+
+class _FakeNestedTransaction:
+    """Mimics session.begin_nested(): rolls back to the savepoint and re-raises on error."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _make_watched() -> SimpleNamespace:
+    return SimpleNamespace(
+        id="watched-1",
+        user_id="user-1",
+        media_item_id="media-1",
+        episode_item_id=None,
+        watched_at=NOW,
+        rating=None,
+    )
+
+
+def _make_show_without_ids() -> SimpleNamespace:
+    return SimpleNamespace(
+        id="media-1",
+        media_type="tv",
+        imdb_id=None,
+        tmdb_id=None,
+        tvdb_id=None,
+        tvmaze_id=None,
+        kitsu_id=None,
+        myanimelist_id=None,
+        anilist_id=None,
+        title="Sample Show",
+        year=2011,
+        poster_url=None,
+        first_air_date=None,
+        raw={},
+    )
+
+
+def _make_db(watched, media_item, execute_side_effects):
+    async def fake_get(model, pk):
+        if model.__name__ == "WatchedItem":
+            return watched
+        if model.__name__ == "MediaItem":
+            return media_item
+        return None
+
+    return SimpleNamespace(
+        get=AsyncMock(side_effect=fake_get),
+        execute=AsyncMock(side_effect=execute_side_effects),
+        add=MagicMock(),
+        flush=AsyncMock(),
+        begin_nested=MagicMock(return_value=_FakeNestedTransaction()),
+    )
+
+
+def _make_job() -> SimpleNamespace:
+    return SimpleNamespace(payload={"watched_item_id": "watched-1"})
+
+
+def test_first_watch_creates_and_evaluates_show_watchlist_item_exactly_once() -> None:
+    watched = _make_watched()
+    media_item = _make_show_without_ids()
+    db = _make_db(
+        watched,
+        media_item,
+        execute_side_effects=[
+            _FakeResult(scalar=None),  # ensure: no existing watchlist item
+        ],
+    )
+
+    with (
+        patch("librarysync.core.watch_pipeline.enrich_watched_metadata", new_callable=AsyncMock),
+        patch("librarysync.core.watch_pipeline.backfill_show_episodes", new_callable=AsyncMock),
+        patch("librarysync.core.watch_pipeline._sync_to_integrations", new_callable=AsyncMock),
+        patch(
+            "librarysync.core.watchlist.evaluate_show_watchlist_status", new_callable=AsyncMock
+        ) as evaluate,
+        patch("librarysync.core.watchlist._enqueue_watchlist_sync", new_callable=AsyncMock) as sync,
+    ):
+        asyncio.run(process_new_item_job(db, _make_job()))
+
+    # Newly created item is evaluated by ensure_show_watchlist_item; the
+    # follow-up check_and_update_watchlist must be skipped.
+    assert evaluate.await_count == 1
+    # Auto-created item is pushed to connected providers exactly once.
+    assert sync.await_count == 1
+    sync_args = sync.await_args.args
+    assert sync_args[0] is db
+    assert sync_args[1].media_item_id == "media-1"
+    assert sync_args[2] is media_item
+
+
+def test_second_watch_evaluates_existing_item_exactly_once_without_push() -> None:
+    watched = _make_watched()
+    media_item = _make_show_without_ids()
+    existing_item = SimpleNamespace(
+        id="wl-existing",
+        user_id="user-1",
+        media_item_id="media-1",
+        status="added",
+        rewatch_requested=False,
+    )
+    db = _make_db(
+        watched,
+        media_item,
+        execute_side_effects=[
+            _FakeResult(scalar=existing_item),  # ensure: item already exists
+            _FakeResult(scalar=existing_item),  # check_and_update: fetch item
+            _FakeResult(scalar=media_item),  # check_and_update: fetch media item
+        ],
+    )
+
+    with (
+        patch("librarysync.core.watch_pipeline.enrich_watched_metadata", new_callable=AsyncMock),
+        patch("librarysync.core.watch_pipeline.backfill_show_episodes", new_callable=AsyncMock),
+        patch("librarysync.core.watch_pipeline._sync_to_integrations", new_callable=AsyncMock),
+        patch(
+            "librarysync.core.watchlist.evaluate_show_watchlist_status", new_callable=AsyncMock
+        ) as evaluate,
+        patch("librarysync.core.watchlist._enqueue_watchlist_sync", new_callable=AsyncMock) as sync,
+    ):
+        asyncio.run(process_new_item_job(db, _make_job()))
+
+    # Pre-existing item is evaluated once by check_and_update_watchlist.
+    assert evaluate.await_count == 1
+    evaluate.assert_awaited_with(db, "user-1", existing_item, media_item)
+    sync.assert_not_awaited()
+
+
+def test_pipeline_skips_check_and_update_when_item_was_created_and_evaluated() -> None:
+    watched = _make_watched()
+    media_item = _make_show_without_ids()
+    db = _make_db(watched, media_item, execute_side_effects=[])
+
+    with (
+        patch("librarysync.core.watch_pipeline.enrich_watched_metadata", new_callable=AsyncMock),
+        patch("librarysync.core.watch_pipeline.backfill_show_episodes", new_callable=AsyncMock),
+        patch("librarysync.core.watch_pipeline._sync_to_integrations", new_callable=AsyncMock),
+        patch(
+            "librarysync.core.watch_pipeline.ensure_show_watchlist_item",
+            new_callable=AsyncMock,
+            return_value=(SimpleNamespace(id="wl-1"), True),
+        ),
+        patch(
+            "librarysync.core.watch_pipeline.check_and_update_watchlist", new_callable=AsyncMock
+        ) as check,
+    ):
+        asyncio.run(process_new_item_job(db, _make_job()))
+
+    check.assert_not_awaited()
+
+
+def test_pipeline_runs_check_and_update_when_item_already_existed() -> None:
+    watched = _make_watched()
+    media_item = _make_show_without_ids()
+    db = _make_db(watched, media_item, execute_side_effects=[])
+
+    with (
+        patch("librarysync.core.watch_pipeline.enrich_watched_metadata", new_callable=AsyncMock),
+        patch("librarysync.core.watch_pipeline.backfill_show_episodes", new_callable=AsyncMock),
+        patch("librarysync.core.watch_pipeline._sync_to_integrations", new_callable=AsyncMock),
+        patch(
+            "librarysync.core.watch_pipeline.ensure_show_watchlist_item",
+            new_callable=AsyncMock,
+            return_value=(SimpleNamespace(id="wl-1"), False),
+        ),
+        patch(
+            "librarysync.core.watch_pipeline.check_and_update_watchlist", new_callable=AsyncMock
+        ) as check,
+    ):
+        asyncio.run(process_new_item_job(db, _make_job()))
+
+    check.assert_awaited_once_with(db, "user-1", "media-1", watched_at=NOW)

--- a/backend/tests/test_watchlist_from_history.py
+++ b/backend/tests/test_watchlist_from_history.py
@@ -1,0 +1,177 @@
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+
+from librarysync.core import watchlist
+from librarysync.db.models import WatchlistItem
+
+
+def _as_media_item(value: Any) -> Any:
+    return cast(Any, value)
+
+
+def _make_show(media_type: str = "tv") -> SimpleNamespace:
+    return SimpleNamespace(
+        id="media-1",
+        media_type=media_type,
+        imdb_id="tt1234567",
+        tmdb_id="1399",
+        tvdb_id=None,
+        tvmaze_id=None,
+        kitsu_id=None,
+        myanimelist_id=None,
+        anilist_id=None,
+        title="Sample Show",
+        year=2011,
+        poster_url="https://example.com/poster.jpg",
+    )
+
+
+class _FakeScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def first(self):
+        return self._value
+
+
+class _FakeResult:
+    def __init__(self, scalar=None):
+        self._scalar = scalar
+
+    def scalars(self):
+        return _FakeScalarResult(self._scalar)
+
+
+def test_ensure_show_watchlist_item_adds_tv_show_from_history() -> None:
+    now = datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc)
+    db = SimpleNamespace(execute=AsyncMock(return_value=_FakeResult(scalar=None)))
+
+    with patch("librarysync.core.watchlist.upsert_watchlist_item", new_callable=AsyncMock) as upsert:
+        upsert.return_value = (SimpleNamespace(id="wl-1"), "created")
+
+        asyncio.run(
+            watchlist.ensure_show_watchlist_item(
+                db=db,
+                user_id="user-1",
+                media_item=_as_media_item(_make_show("tv")),
+                watched_at=now,
+            )
+        )
+
+    upsert.assert_awaited_once_with(
+        ANY,
+        "user-1",
+        "tv",
+        {
+            "imdb_id": "tt1234567",
+            "tmdb_id": "1399",
+        },
+        "Sample Show",
+        2011,
+        "https://example.com/poster.jpg",
+        "auto_from_history",
+        now=now,
+        event_raw={},
+    )
+
+
+def test_ensure_show_watchlist_item_skips_non_show_types() -> None:
+    with patch("librarysync.core.watchlist.upsert_watchlist_item", new_callable=AsyncMock) as upsert:
+        asyncio.run(
+            watchlist.ensure_show_watchlist_item(
+                db=SimpleNamespace(),
+                user_id="user-1",
+                media_item=_as_media_item(_make_show("movie")),
+                watched_at=datetime(2026, 7, 18, tzinfo=timezone.utc),
+            )
+        )
+
+    upsert.assert_not_awaited()
+
+
+def test_ensure_show_watchlist_item_returns_existing_without_ids() -> None:
+    media_item = _make_show("tv")
+    media_item.imdb_id = None
+    media_item.tmdb_id = None
+    media_item.tvdb_id = None
+    media_item.tvmaze_id = None
+    media_item.kitsu_id = None
+    media_item.myanimelist_id = None
+    media_item.anilist_id = None
+
+    existing_item = SimpleNamespace(id="wl-existing", user_id="user-1", media_item_id="media-1")
+    db = SimpleNamespace(
+        execute=AsyncMock(return_value=_FakeResult(scalar=existing_item)),
+        add=MagicMock(),
+        flush=AsyncMock(),
+    )
+
+    with (
+        patch("librarysync.core.watchlist.upsert_watchlist_item", new_callable=AsyncMock) as upsert,
+        patch("librarysync.core.watchlist.evaluate_show_watchlist_status", new_callable=AsyncMock) as evaluate,
+    ):
+        result = asyncio.run(
+            watchlist.ensure_show_watchlist_item(
+                db=db,
+                user_id="user-1",
+                media_item=_as_media_item(media_item),
+                watched_at=datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc),
+            )
+        )
+
+    assert result is existing_item
+    db.add.assert_not_called()
+    db.flush.assert_not_awaited()
+    upsert.assert_not_awaited()
+    evaluate.assert_not_awaited()
+
+
+def test_ensure_show_watchlist_item_creates_missing_without_ids() -> None:
+    media_item = _make_show("tv")
+    media_item.imdb_id = None
+    media_item.tmdb_id = None
+    media_item.tvdb_id = None
+    media_item.tvmaze_id = None
+    media_item.kitsu_id = None
+    media_item.myanimelist_id = None
+    media_item.anilist_id = None
+    media_item.first_air_date = None
+
+    db = SimpleNamespace(
+        execute=AsyncMock(return_value=_FakeResult(scalar=None)),
+        add=MagicMock(),
+        flush=AsyncMock(),
+    )
+
+    with (
+        patch("librarysync.core.watchlist.log_watchlist_event", new_callable=AsyncMock) as log_event,
+        patch("librarysync.core.watchlist.evaluate_show_watchlist_status", new_callable=AsyncMock) as evaluate,
+    ):
+        result = asyncio.run(
+            watchlist.ensure_show_watchlist_item(
+                db=db,
+                user_id="user-1",
+                media_item=_as_media_item(media_item),
+                watched_at=datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc),
+            )
+        )
+
+    assert isinstance(result, WatchlistItem)
+    assert result.user_id == "user-1"
+    assert result.media_item_id == media_item.id
+    assert result.type == "tv"
+    assert result.status == "added"
+    assert result.source == "auto_from_history"
+    db.add.assert_called_once()
+    db.flush.assert_awaited_once()
+    log_event.assert_awaited_once_with(
+        db,
+        "user-1",
+        media_item.id,
+        "watchlist_added",
+        {"source": "auto_from_history"},
+    )
+    evaluate.assert_awaited_once_with(db, "user-1", result, media_item)

--- a/backend/tests/test_watchlist_from_history.py
+++ b/backend/tests/test_watchlist_from_history.py
@@ -4,8 +4,10 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
+import pytest
 from librarysync.core import watchlist
 from librarysync.db.models import WatchlistItem
+from sqlalchemy.exc import IntegrityError
 
 
 def _as_media_item(value: Any) -> Any:
@@ -26,7 +28,16 @@ def _make_show(media_type: str = "tv") -> SimpleNamespace:
         title="Sample Show",
         year=2011,
         poster_url="https://example.com/poster.jpg",
+        first_air_date=None,
+        raw={},
     )
+
+
+def _make_show_without_ids(media_type: str = "tv") -> SimpleNamespace:
+    show = _make_show(media_type)
+    show.imdb_id = None
+    show.tmdb_id = None
+    return show
 
 
 class _FakeScalarResult:
@@ -45,14 +56,42 @@ class _FakeResult:
         return _FakeScalarResult(self._scalar)
 
 
+class _FakeNestedTransaction:
+    """Mimics session.begin_nested(): rolls back to the savepoint and re-raises on error."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _make_db(**overrides: Any) -> SimpleNamespace:
+    db = SimpleNamespace(
+        execute=AsyncMock(return_value=_FakeResult(scalar=None)),
+        add=MagicMock(),
+        flush=AsyncMock(),
+        begin_nested=MagicMock(return_value=_FakeNestedTransaction()),
+    )
+    for key, value in overrides.items():
+        setattr(db, key, value)
+    return db
+
+
+def _unique_violation(constraint: str = "uq_watchlist_items_user_media") -> IntegrityError:
+    orig = SimpleNamespace(diag=SimpleNamespace(constraint_name=constraint))
+    return IntegrityError("INSERT INTO watchlist_items ...", {}, orig)
+
+
 def test_ensure_show_watchlist_item_adds_tv_show_from_history() -> None:
     now = datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc)
-    db = SimpleNamespace(execute=AsyncMock(return_value=_FakeResult(scalar=None)))
+    db = _make_db()
+    created_item = SimpleNamespace(id="wl-1")
 
     with patch("librarysync.core.watchlist.upsert_watchlist_item", new_callable=AsyncMock) as upsert:
-        upsert.return_value = (SimpleNamespace(id="wl-1"), "created")
+        upsert.return_value = (created_item, "created")
 
-        asyncio.run(
+        result = asyncio.run(
             watchlist.ensure_show_watchlist_item(
                 db=db,
                 user_id="user-1",
@@ -61,6 +100,7 @@ def test_ensure_show_watchlist_item_adds_tv_show_from_history() -> None:
             )
         )
 
+    assert result == (created_item, True)
     upsert.assert_awaited_once_with(
         ANY,
         "user-1",
@@ -75,12 +115,13 @@ def test_ensure_show_watchlist_item_adds_tv_show_from_history() -> None:
         "auto_from_history",
         now=now,
         event_raw={},
+        enqueue_sync=True,
     )
 
 
 def test_ensure_show_watchlist_item_skips_non_show_types() -> None:
     with patch("librarysync.core.watchlist.upsert_watchlist_item", new_callable=AsyncMock) as upsert:
-        asyncio.run(
+        result = asyncio.run(
             watchlist.ensure_show_watchlist_item(
                 db=SimpleNamespace(),
                 user_id="user-1",
@@ -89,29 +130,21 @@ def test_ensure_show_watchlist_item_skips_non_show_types() -> None:
             )
         )
 
+    assert result == (None, False)
     upsert.assert_not_awaited()
 
 
 def test_ensure_show_watchlist_item_returns_existing_without_ids() -> None:
-    media_item = _make_show("tv")
-    media_item.imdb_id = None
-    media_item.tmdb_id = None
-    media_item.tvdb_id = None
-    media_item.tvmaze_id = None
-    media_item.kitsu_id = None
-    media_item.myanimelist_id = None
-    media_item.anilist_id = None
+    media_item = _make_show_without_ids("tv")
 
     existing_item = SimpleNamespace(id="wl-existing", user_id="user-1", media_item_id="media-1")
-    db = SimpleNamespace(
-        execute=AsyncMock(return_value=_FakeResult(scalar=existing_item)),
-        add=MagicMock(),
-        flush=AsyncMock(),
-    )
+    db = _make_db(execute=AsyncMock(return_value=_FakeResult(scalar=existing_item)))
 
     with (
         patch("librarysync.core.watchlist.upsert_watchlist_item", new_callable=AsyncMock) as upsert,
-        patch("librarysync.core.watchlist.evaluate_show_watchlist_status", new_callable=AsyncMock) as evaluate,
+        patch(
+            "librarysync.core.watchlist.evaluate_show_watchlist_status", new_callable=AsyncMock
+        ) as evaluate,
     ):
         result = asyncio.run(
             watchlist.ensure_show_watchlist_item(
@@ -122,7 +155,7 @@ def test_ensure_show_watchlist_item_returns_existing_without_ids() -> None:
             )
         )
 
-    assert result is existing_item
+    assert result == (existing_item, False)
     db.add.assert_not_called()
     db.flush.assert_not_awaited()
     upsert.assert_not_awaited()
@@ -130,27 +163,17 @@ def test_ensure_show_watchlist_item_returns_existing_without_ids() -> None:
 
 
 def test_ensure_show_watchlist_item_creates_missing_without_ids() -> None:
-    media_item = _make_show("tv")
-    media_item.imdb_id = None
-    media_item.tmdb_id = None
-    media_item.tvdb_id = None
-    media_item.tvmaze_id = None
-    media_item.kitsu_id = None
-    media_item.myanimelist_id = None
-    media_item.anilist_id = None
-    media_item.first_air_date = None
-
-    db = SimpleNamespace(
-        execute=AsyncMock(return_value=_FakeResult(scalar=None)),
-        add=MagicMock(),
-        flush=AsyncMock(),
-    )
+    media_item = _make_show_without_ids("tv")
+    db = _make_db()
 
     with (
         patch("librarysync.core.watchlist.log_watchlist_event", new_callable=AsyncMock) as log_event,
-        patch("librarysync.core.watchlist.evaluate_show_watchlist_status", new_callable=AsyncMock) as evaluate,
+        patch(
+            "librarysync.core.watchlist.evaluate_show_watchlist_status", new_callable=AsyncMock
+        ) as evaluate,
+        patch("librarysync.core.watchlist._enqueue_watchlist_sync", new_callable=AsyncMock) as sync,
     ):
-        result = asyncio.run(
+        item, evaluated = asyncio.run(
             watchlist.ensure_show_watchlist_item(
                 db=db,
                 user_id="user-1",
@@ -159,12 +182,14 @@ def test_ensure_show_watchlist_item_creates_missing_without_ids() -> None:
             )
         )
 
-    assert isinstance(result, WatchlistItem)
-    assert result.user_id == "user-1"
-    assert result.media_item_id == media_item.id
-    assert result.type == "tv"
-    assert result.status == "added"
-    assert result.source == "auto_from_history"
+    assert evaluated is True
+    assert isinstance(item, WatchlistItem)
+    assert item.user_id == "user-1"
+    assert item.media_item_id == media_item.id
+    assert item.type == "tv"
+    assert item.status == "added"
+    assert item.source == "auto_from_history"
+    db.begin_nested.assert_called_once()
     db.add.assert_called_once()
     db.flush.assert_awaited_once()
     log_event.assert_awaited_once_with(
@@ -174,4 +199,258 @@ def test_ensure_show_watchlist_item_creates_missing_without_ids() -> None:
         "watchlist_added",
         {"source": "auto_from_history"},
     )
-    evaluate.assert_awaited_once_with(db, "user-1", result, media_item)
+    evaluate.assert_awaited_once_with(db, "user-1", item, media_item)
+    sync.assert_awaited_once_with(db, item, media_item)
+
+
+def test_ensure_show_watchlist_item_recovers_from_insert_race() -> None:
+    media_item = _make_show_without_ids("tv")
+    existing_item = SimpleNamespace(
+        id="wl-existing",
+        user_id="user-1",
+        media_item_id="media-1",
+        status="added",
+    )
+    db = _make_db(
+        execute=AsyncMock(
+            side_effect=[
+                _FakeResult(scalar=None),  # initial existence check
+                _FakeResult(scalar=existing_item),  # re-fetch after unique violation
+            ]
+        ),
+        flush=AsyncMock(side_effect=_unique_violation()),
+    )
+
+    with (
+        patch("librarysync.core.watchlist.log_watchlist_event", new_callable=AsyncMock),
+        patch(
+            "librarysync.core.watchlist.evaluate_show_watchlist_status", new_callable=AsyncMock
+        ) as evaluate,
+        patch("librarysync.core.watchlist._enqueue_watchlist_sync", new_callable=AsyncMock) as sync,
+    ):
+        item, evaluated = asyncio.run(
+            watchlist.ensure_show_watchlist_item(
+                db=db,
+                user_id="user-1",
+                media_item=_as_media_item(media_item),
+                watched_at=datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc),
+            )
+        )
+
+    assert item is existing_item
+    assert evaluated is False
+    evaluate.assert_not_awaited()
+    sync.assert_not_awaited()
+
+
+def test_ensure_show_watchlist_item_reraises_unrelated_integrity_error() -> None:
+    media_item = _make_show_without_ids("tv")
+    db = _make_db(
+        flush=AsyncMock(side_effect=_unique_violation("uq_some_other_constraint")),
+    )
+
+    with patch("librarysync.core.watchlist.log_watchlist_event", new_callable=AsyncMock):
+        with pytest.raises(IntegrityError):
+            asyncio.run(
+                watchlist.ensure_show_watchlist_item(
+                    db=db,
+                    user_id="user-1",
+                    media_item=_as_media_item(media_item),
+                    watched_at=datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc),
+                )
+            )
+
+
+def test_upsert_watchlist_item_recovers_from_insert_race() -> None:
+    media_item = _make_show("tv")
+    existing_item = SimpleNamespace(
+        id="wl-existing",
+        user_id="user-1",
+        media_item_id="media-1",
+        status="added",
+        source="auto_from_history",
+    )
+    db = _make_db(
+        execute=AsyncMock(
+            side_effect=[
+                _FakeResult(scalar=media_item),  # find_media_item_by_ids
+                _FakeResult(scalar=None),  # initial watchlist existence check
+                _FakeResult(scalar=existing_item),  # re-fetch after unique violation
+            ]
+        ),
+        flush=AsyncMock(side_effect=_unique_violation()),
+    )
+
+    with (
+        patch("librarysync.core.watchlist.log_watchlist_event", new_callable=AsyncMock),
+        patch(
+            "librarysync.core.watchlist.evaluate_show_watchlist_status", new_callable=AsyncMock
+        ) as evaluate,
+        patch("librarysync.core.watchlist._enqueue_watchlist_sync", new_callable=AsyncMock) as sync,
+    ):
+        result = asyncio.run(
+            watchlist.upsert_watchlist_item(
+                db,
+                "user-1",
+                "tv",
+                {"imdb_id": "tt1234567", "tmdb_id": "1399"},
+                "Sample Show",
+                2011,
+                "https://example.com/poster.jpg",
+                "auto_from_history",
+                enqueue_sync=True,
+            )
+        )
+
+    assert result == (existing_item, "already_exists")
+    evaluate.assert_not_awaited()
+    # The concurrent writer that inserted the row owns the sync push.
+    sync.assert_not_awaited()
+
+
+def test_upsert_watchlist_item_reraises_unrelated_integrity_error() -> None:
+    media_item = _make_show("tv")
+    db = _make_db(
+        execute=AsyncMock(
+            side_effect=[
+                _FakeResult(scalar=media_item),  # find_media_item_by_ids
+                _FakeResult(scalar=None),  # initial watchlist existence check
+            ]
+        ),
+        flush=AsyncMock(side_effect=_unique_violation("uq_some_other_constraint")),
+    )
+
+    with patch("librarysync.core.watchlist.log_watchlist_event", new_callable=AsyncMock):
+        with pytest.raises(IntegrityError):
+            asyncio.run(
+                watchlist.upsert_watchlist_item(
+                    db,
+                    "user-1",
+                    "tv",
+                    {"imdb_id": "tt1234567", "tmdb_id": "1399"},
+                    "Sample Show",
+                    2011,
+                    None,
+                    "auto_from_history",
+                )
+            )
+
+
+def test_upsert_watchlist_item_enqueues_sync_on_create_when_requested() -> None:
+    media_item = _make_show("tv")
+    db = _make_db(
+        execute=AsyncMock(
+            side_effect=[
+                _FakeResult(scalar=media_item),  # find_media_item_by_ids
+                _FakeResult(scalar=None),  # initial watchlist existence check
+            ]
+        ),
+    )
+
+    with (
+        patch("librarysync.core.watchlist.log_watchlist_event", new_callable=AsyncMock),
+        patch(
+            "librarysync.core.watchlist.evaluate_show_watchlist_status", new_callable=AsyncMock
+        ) as evaluate,
+        patch("librarysync.core.watchlist._enqueue_watchlist_sync", new_callable=AsyncMock) as sync,
+    ):
+        item, status = asyncio.run(
+            watchlist.upsert_watchlist_item(
+                db,
+                "user-1",
+                "tv",
+                {"imdb_id": "tt1234567", "tmdb_id": "1399"},
+                "Sample Show",
+                2011,
+                None,
+                "auto_from_history",
+                enqueue_sync=True,
+            )
+        )
+
+    assert status == "created"
+    assert isinstance(item, WatchlistItem)
+    evaluate.assert_awaited_once_with(db, "user-1", item, media_item)
+    sync.assert_awaited_once_with(db, item, media_item)
+
+
+def test_upsert_watchlist_item_does_not_enqueue_sync_by_default() -> None:
+    # Default path used by the manual API route (enqueues itself) and import pipeline.
+    media_item = _make_show("tv")
+    db = _make_db(
+        execute=AsyncMock(
+            side_effect=[
+                _FakeResult(scalar=media_item),  # find_media_item_by_ids
+                _FakeResult(scalar=None),  # initial watchlist existence check
+            ]
+        ),
+    )
+
+    with (
+        patch("librarysync.core.watchlist.log_watchlist_event", new_callable=AsyncMock),
+        patch("librarysync.core.watchlist.evaluate_show_watchlist_status", new_callable=AsyncMock),
+        patch("librarysync.core.watchlist._enqueue_watchlist_sync", new_callable=AsyncMock) as sync,
+    ):
+        item, status = asyncio.run(
+            watchlist.upsert_watchlist_item(
+                db,
+                "user-1",
+                "tv",
+                {"imdb_id": "tt1234567", "tmdb_id": "1399"},
+                "Sample Show",
+                2011,
+                None,
+                "manual",
+            )
+        )
+
+    assert status == "created"
+    assert isinstance(item, WatchlistItem)
+    sync.assert_not_awaited()
+
+
+def test_upsert_watchlist_item_enqueues_sync_on_restore_when_requested() -> None:
+    media_item = _make_show("tv")
+    removed_item = SimpleNamespace(
+        id="wl-removed",
+        user_id="user-1",
+        media_item_id="media-1",
+        status="removed",
+        source="auto_from_history",
+        updated_at=None,
+    )
+    db = _make_db(
+        execute=AsyncMock(
+            side_effect=[
+                _FakeResult(scalar=media_item),  # find_media_item_by_ids
+                _FakeResult(scalar=removed_item),  # initial watchlist existence check
+            ]
+        ),
+    )
+
+    with (
+        patch("librarysync.core.watchlist.log_watchlist_event", new_callable=AsyncMock),
+        patch(
+            "librarysync.core.watchlist.evaluate_show_watchlist_status", new_callable=AsyncMock
+        ) as evaluate,
+        patch("librarysync.core.watchlist._enqueue_watchlist_sync", new_callable=AsyncMock) as sync,
+    ):
+        item, status = asyncio.run(
+            watchlist.upsert_watchlist_item(
+                db,
+                "user-1",
+                "tv",
+                {"imdb_id": "tt1234567", "tmdb_id": "1399"},
+                "Sample Show",
+                2011,
+                None,
+                "auto_from_history",
+                enqueue_sync=True,
+            )
+        )
+
+    assert status == "restored"
+    assert item is removed_item
+    assert removed_item.status == "added"
+    evaluate.assert_awaited_once_with(db, "user-1", removed_item, media_item)
+    sync.assert_awaited_once_with(db, removed_item, media_item)

--- a/backend/tests/test_watchlist_refresh.py
+++ b/backend/tests/test_watchlist_refresh.py
@@ -1,0 +1,116 @@
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+from librarysync.jobs import watchlist_refresh
+
+
+def _as(value: Any) -> Any:
+    return cast(Any, value)
+
+
+class _FakeScalars:
+    def __init__(self, values):
+        self._values = values
+
+    def all(self):
+        return self._values
+
+
+class _FakeResult:
+    def __init__(self, values=()):
+        self._values = list(values)
+
+    def scalars(self):
+        return _FakeScalars(self._values)
+
+    def all(self):
+        return list(self._values)
+
+
+def _make_media(media_id: str, media_type: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=media_id,
+        media_type=media_type,
+        imdb_id="tt1234567",
+        tmdb_id="1399",
+    )
+
+
+def test_refresh_dispatches_anime_to_show_status_evaluation() -> None:
+    movie_item = SimpleNamespace(status="added")
+    tv_item = SimpleNamespace(status="added")
+    anime_item = SimpleNamespace(status="added")
+    movie = _make_media("media-movie", "movie")
+    tv = _make_media("media-tv", "tv")
+    anime = _make_media("media-anime", "anime")
+    rows = [(movie_item, movie), (tv_item, tv), (anime_item, anime)]
+
+    db = SimpleNamespace(
+        execute=AsyncMock(return_value=_FakeResult(["user-1"])),
+        commit=AsyncMock(),
+    )
+    job = SimpleNamespace(last_run_at=None)
+
+    with (
+        patch.object(
+            watchlist_refresh, "_load_watchlist_rows_for_refresh", new_callable=AsyncMock
+        ) as load_rows,
+        patch.object(
+            watchlist_refresh, "_backfill_missing_show_episodes", new_callable=AsyncMock
+        ),
+        patch.object(
+            watchlist_refresh, "evaluate_show_watchlist_status", new_callable=AsyncMock
+        ) as evaluate,
+        patch.object(watchlist_refresh, "_refresh_movie_status", new_callable=AsyncMock) as refresh_movie,
+        patch.object(watchlist_refresh, "extend_scheduled_job", new_callable=AsyncMock),
+    ):
+        load_rows.return_value = rows
+        asyncio.run(watchlist_refresh.run_watchlist_refresh(db, _as(job)))
+
+    refresh_movie.assert_awaited_once_with(db, "user-1", movie_item, movie)
+    assert evaluate.await_count == 2
+    evaluated_media = [call.args[3] for call in evaluate.await_args_list]
+    assert evaluated_media == [tv, anime]
+
+
+def test_backfill_missing_show_episodes_covers_tv_and_anime() -> None:
+    tv_item = SimpleNamespace(status="added")
+    anime_item = SimpleNamespace(status="added")
+    movie_item = SimpleNamespace(status="added")
+    tv = _make_media("media-tv", "tv")
+    anime = _make_media("media-anime", "anime")
+    movie = _make_media("media-movie", "movie")
+    rows = [(tv_item, tv), (anime_item, anime), (movie_item, movie)]
+
+    db = SimpleNamespace(execute=AsyncMock(return_value=_FakeResult([])))
+
+    with patch.object(watchlist_refresh, "backfill_show_episodes", new_callable=AsyncMock) as backfill:
+        asyncio.run(watchlist_refresh._backfill_missing_show_episodes(db, "user-1", _as(rows)))
+
+    assert backfill.await_count == 2
+    backfilled_media = [call.args[2] for call in backfill.await_args_list]
+    assert backfilled_media == [tv, anime]
+
+
+def test_load_rows_episode_queries_treat_anime_like_tv() -> None:
+    execute = AsyncMock(return_value=_FakeResult([]))
+    db = SimpleNamespace(execute=execute)
+    last_run_at = datetime(2026, 7, 17, 10, 0, tzinfo=timezone.utc)
+
+    result = asyncio.run(watchlist_refresh._load_watchlist_rows_for_refresh(db, "user-1", last_run_at))
+
+    assert result == []
+    compiled_queries = [
+        str(call.args[0].compile(compile_kwargs={"literal_binds": True})).lower()
+        for call in execute.await_args_list
+    ]
+    assert compiled_queries
+    for compiled in compiled_queries:
+        assert "media_items.media_type = 'tv'" not in compiled
+    episode_queries = [compiled for compiled in compiled_queries if "episode_items" in compiled]
+    assert episode_queries
+    for compiled in episode_queries:
+        assert "media_items.media_type in ('tv', 'anime')" in compiled


### PR DESCRIPTION
## Summary
- auto-add parent tv/anime shows to a user's watchlist when new episode watches are processed
- backfill watchlist rows from existing watched show history via Alembic migration
- add focused TDD coverage for watchlist creation, pipeline hook, and migration behavior

## Verification
- uv run pytest
- uv run ruff check