### PR TITLE
Add 30m/1h quick import schedules and single-flight lease

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ Handles job types: `push_watched`, `push_rating`, `update_history`, `remove_hist
 - **`metadata_backfill`**: Periodically refreshes metadata/enriches watched history and episode lists that are missing posters or identifiers
 
 #### Import Jobs
-- **`quick_import`**: Runs 7-day import window
+- **`quick_import`**: Runs 7-day import window on the user's configured schedule (30 min to 7 days). Per-user runs are single-flight via a lease stored in the integration config (10-minute expiry, refreshed at each claim); an expired lease lets any worker resume a stuck run from its saved queue index
 - **`import_all`**: Sequences providers per user for full import
 - **`merge_history`**: Post-import deduplication (same-day movie entries) and repoints sync/outbox rows
 - **`merge_all_history`**: Periodic deduplication of all user history in database (API merges on-the-fly until DB is clean)

--- a/backend/src/librarysync/core/import_control.py
+++ b/backend/src/librarysync/core/import_control.py
@@ -28,6 +28,12 @@ QUICK_IMPORT_COMPLETED_KEY = "quick_import_completed_at"
 QUICK_IMPORT_ERROR_KEY = "quick_import_error"
 QUICK_IMPORT_INTERVAL_KEY = "quick_import_interval_seconds"
 QUICK_IMPORT_LAST_RUN_KEY = "quick_import_last_run_at"
+QUICK_IMPORT_LEASE_OWNER_KEY = "quick_import_lease_owner"
+QUICK_IMPORT_LEASE_UNTIL_KEY = "quick_import_lease_until"
+
+# How long a worker holds a quick import run without refreshing the lease.
+# An expired lease lets another worker resume a stuck run (self-heal).
+QUICK_IMPORT_LEASE_SECONDS = 600
 
 QUICK_IMPORT_ACTIVE_STATUSES = {
     QUICK_IMPORT_STATUS_PENDING,
@@ -128,8 +134,32 @@ def mark_quick_import_started(config: dict | None, started_at: datetime) -> dict
     return updated
 
 
-def mark_quick_import_completed(config: dict | None, completed_at: datetime) -> dict:
+def quick_import_lease_blocked(config: dict | None, now: datetime, owner: str) -> bool:
+    """Return True when another worker holds a live lease on the run."""
+    config = config or {}
+    lease_until = parse_datetime(config.get(QUICK_IMPORT_LEASE_UNTIL_KEY))
+    if not lease_until or lease_until <= now:
+        return False
+    lease_owner = coerce_str(config.get(QUICK_IMPORT_LEASE_OWNER_KEY))
+    return lease_owner != owner
+
+
+def mark_quick_import_lease(config: dict | None, owner: str, now: datetime) -> dict:
     updated = dict(config or {})
+    updated[QUICK_IMPORT_LEASE_OWNER_KEY] = owner
+    updated[QUICK_IMPORT_LEASE_UNTIL_KEY] = (now + timedelta(seconds=QUICK_IMPORT_LEASE_SECONDS)).isoformat()
+    return updated
+
+
+def clear_quick_import_lease(config: dict | None) -> dict:
+    updated = dict(config or {})
+    updated.pop(QUICK_IMPORT_LEASE_OWNER_KEY, None)
+    updated.pop(QUICK_IMPORT_LEASE_UNTIL_KEY, None)
+    return updated
+
+
+def mark_quick_import_completed(config: dict | None, completed_at: datetime) -> dict:
+    updated = clear_quick_import_lease(config)
     updated[QUICK_IMPORT_STATUS_KEY] = QUICK_IMPORT_STATUS_COMPLETED
     updated[QUICK_IMPORT_COMPLETED_KEY] = completed_at.isoformat()
     updated[QUICK_IMPORT_LAST_RUN_KEY] = completed_at.isoformat()
@@ -139,7 +169,7 @@ def mark_quick_import_completed(config: dict | None, completed_at: datetime) -> 
 
 
 def mark_quick_import_failed(config: dict | None, failed_at: datetime, error: str) -> dict:
-    updated = dict(config or {})
+    updated = clear_quick_import_lease(config)
     updated[QUICK_IMPORT_STATUS_KEY] = QUICK_IMPORT_STATUS_FAILED
     updated[QUICK_IMPORT_COMPLETED_KEY] = failed_at.isoformat()
     updated[QUICK_IMPORT_ERROR_KEY] = error

--- a/backend/src/librarysync/jobs/imports.py
+++ b/backend/src/librarysync/jobs/imports.py
@@ -35,8 +35,10 @@ from librarysync.core.import_control import (
     mark_merge_required,
     mark_quick_import_completed,
     mark_quick_import_failed,
+    mark_quick_import_lease,
     mark_quick_import_started,
     parse_quick_import_state,
+    quick_import_lease_blocked,
     should_run_quick_import,
 )
 from librarysync.core.import_history import (
@@ -45,6 +47,7 @@ from librarysync.core.import_history import (
     build_import_history_entry,
 )
 from librarysync.core.import_schedule import parse_datetime
+from librarysync.core.worker_identity import worker_instance_id
 from librarysync.db.models import Integration
 from librarysync.db.session import SessionLocal, init_session_factory
 from librarysync.jobs.aiostreams_import import AIOStreamsImportStrategy
@@ -150,6 +153,7 @@ async def process_import_all_once(limit: int = 1) -> int:
 
 async def _claim_quick_import_runs(db: AsyncSession, limit: int) -> list[Integration]:
     now = datetime.now(timezone.utc)
+    owner = worker_instance_id()
     candidate_limit = max(limit * 5, limit)
     async with db.begin():
         result = await db.execute(
@@ -167,6 +171,10 @@ async def _claim_quick_import_runs(db: AsyncSession, limit: int) -> list[Integra
                 continue
             if not should_run_quick_import(run.config, now):
                 continue
+            # Single-flight: another live worker owns this run. An expired or
+            # missing lease means the run is free (or stuck) and can be claimed.
+            if quick_import_lease_blocked(run.config, now, owner):
+                continue
             state = parse_quick_import_state(run.config)
             if state.status not in {
                 QUICK_IMPORT_STATUS_PENDING,
@@ -181,10 +189,10 @@ async def _claim_quick_import_runs(db: AsyncSession, limit: int) -> list[Integra
                 state = parse_quick_import_state(run.config)
             if state.status == QUICK_IMPORT_STATUS_PENDING:
                 run.config = mark_quick_import_started(run.config, now)
-                run.updated_at = now
             elif not _has_merge_required(run.config):
                 run.config = mark_merge_required(run.config, now)
-                run.updated_at = now
+            run.config = mark_quick_import_lease(run.config, owner, now)
+            run.updated_at = now
             runs.append(run)
     return runs
 

--- a/backend/src/librarysync/templates/settings/imports.html
+++ b/backend/src/librarysync/templates/settings/imports.html
@@ -27,6 +27,8 @@
           <span>Import schedule</span>
           <select class="select" name="quick_import_interval">
             <option value="">Manual only</option>
+            <option value="1800">Every 30 minutes</option>
+            <option value="3600">Every hour</option>
             <option value="21600">Every 6 hours</option>
             <option value="43200">Every 12 hours</option>
             <option value="86400">Every day</option>

--- a/backend/tests/test_quick_import_lease.py
+++ b/backend/tests/test_quick_import_lease.py
@@ -1,0 +1,158 @@
+import asyncio
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(PROJECT_ROOT / "src"))
+
+from librarysync.core.import_control import (  # noqa: E402
+    QUICK_IMPORT_LEASE_OWNER_KEY,
+    QUICK_IMPORT_LEASE_SECONDS,
+    QUICK_IMPORT_LEASE_UNTIL_KEY,
+    clear_quick_import_lease,
+    mark_quick_import_completed,
+    mark_quick_import_failed,
+    mark_quick_import_lease,
+    quick_import_lease_blocked,
+)
+from librarysync.db.models import Integration  # noqa: E402
+from librarysync.jobs import imports  # noqa: E402
+
+NOW = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+WORKER_A = "worker-a"
+WORKER_B = "worker-b"
+
+
+def _leased_config(owner: str, lease_until: datetime) -> dict:
+    return {
+        "quick_import_status": "in_progress",
+        "quick_import_queue": ["trakt", "simkl"],
+        "quick_import_index": 1,
+        "quick_import_started_at": NOW.isoformat(),
+        "merge_required_at": NOW.isoformat(),
+        QUICK_IMPORT_LEASE_OWNER_KEY: owner,
+        QUICK_IMPORT_LEASE_UNTIL_KEY: lease_until.isoformat(),
+    }
+
+
+def _mock_db(integrations: list[Integration]) -> MagicMock:
+    db = MagicMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = integrations
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+class TestQuickImportLeaseHelpers(unittest.TestCase):
+    def test_lease_not_blocked_without_lease(self) -> None:
+        self.assertFalse(quick_import_lease_blocked({}, NOW, WORKER_A))
+        self.assertFalse(quick_import_lease_blocked(None, NOW, WORKER_A))
+
+    def test_lease_not_blocked_when_expired(self) -> None:
+        config = _leased_config(WORKER_B, NOW - timedelta(seconds=1))
+        self.assertFalse(quick_import_lease_blocked(config, NOW, WORKER_A))
+
+    def test_lease_not_blocked_for_same_owner(self) -> None:
+        config = _leased_config(WORKER_A, NOW + timedelta(seconds=60))
+        self.assertFalse(quick_import_lease_blocked(config, NOW, WORKER_A))
+
+    def test_lease_blocked_for_other_owner(self) -> None:
+        config = _leased_config(WORKER_B, NOW + timedelta(seconds=60))
+        self.assertTrue(quick_import_lease_blocked(config, NOW, WORKER_A))
+
+    def test_mark_lease_sets_owner_and_expiry(self) -> None:
+        updated = mark_quick_import_lease({}, WORKER_A, NOW)
+        self.assertEqual(updated[QUICK_IMPORT_LEASE_OWNER_KEY], WORKER_A)
+        lease_until = datetime.fromisoformat(updated[QUICK_IMPORT_LEASE_UNTIL_KEY])
+        self.assertEqual(lease_until, NOW + timedelta(seconds=QUICK_IMPORT_LEASE_SECONDS))
+
+    def test_completed_clears_lease(self) -> None:
+        config = _leased_config(WORKER_A, NOW + timedelta(seconds=60))
+        updated = mark_quick_import_completed(config, NOW)
+        self.assertNotIn(QUICK_IMPORT_LEASE_OWNER_KEY, updated)
+        self.assertNotIn(QUICK_IMPORT_LEASE_UNTIL_KEY, updated)
+
+    def test_failed_clears_lease(self) -> None:
+        config = _leased_config(WORKER_A, NOW + timedelta(seconds=60))
+        updated = mark_quick_import_failed(config, NOW, "boom")
+        self.assertNotIn(QUICK_IMPORT_LEASE_OWNER_KEY, updated)
+        self.assertNotIn(QUICK_IMPORT_LEASE_UNTIL_KEY, updated)
+
+    def test_clear_lease_keeps_other_keys(self) -> None:
+        config = _leased_config(WORKER_A, NOW + timedelta(seconds=60))
+        updated = clear_quick_import_lease(config)
+        self.assertEqual(updated["quick_import_status"], "in_progress")
+        self.assertEqual(updated["quick_import_index"], 1)
+
+
+class TestClaimQuickImportRuns(unittest.TestCase):
+    def _claim(self, integration: Integration) -> list[Integration]:
+        db = _mock_db([integration])
+        with (
+            patch.object(imports, "worker_instance_id", return_value=WORKER_A),
+            patch.object(
+                imports, "build_import_all_queue", new=AsyncMock(return_value=["trakt"])
+            ),
+        ):
+            return asyncio.run(imports._claim_quick_import_runs(db, 1))
+
+    def test_skips_run_leased_by_another_worker(self) -> None:
+        integration = Integration(
+            user_id="user-1",
+            provider="system",
+            config=_leased_config(WORKER_B, datetime.now(timezone.utc) + timedelta(minutes=5)),
+        )
+        runs = self._claim(integration)
+        self.assertEqual(runs, [])
+
+    def test_resumes_stuck_run_with_expired_lease(self) -> None:
+        integration = Integration(
+            user_id="user-1",
+            provider="system",
+            config=_leased_config(WORKER_B, datetime.now(timezone.utc) - timedelta(minutes=5)),
+        )
+        runs = self._claim(integration)
+        self.assertEqual(runs, [integration])
+        config = integration.config
+        # Run is resumed, not restarted: status and progress are preserved.
+        self.assertEqual(config["quick_import_status"], "in_progress")
+        self.assertEqual(config["quick_import_index"], 1)
+        # Lease is taken over by this worker.
+        self.assertEqual(config[QUICK_IMPORT_LEASE_OWNER_KEY], WORKER_A)
+        lease_until = datetime.fromisoformat(config[QUICK_IMPORT_LEASE_UNTIL_KEY])
+        self.assertGreater(lease_until, datetime.now(timezone.utc))
+
+    def test_claims_run_with_lease_held_by_self(self) -> None:
+        integration = Integration(
+            user_id="user-1",
+            provider="system",
+            config=_leased_config(WORKER_A, datetime.now(timezone.utc) + timedelta(minutes=5)),
+        )
+        runs = self._claim(integration)
+        self.assertEqual(runs, [integration])
+
+    def test_starts_scheduled_run_and_takes_lease(self) -> None:
+        integration = Integration(
+            user_id="user-1",
+            provider="system",
+            config={
+                "quick_import_status": "completed",
+                "quick_import_interval_seconds": 1800,
+                "quick_import_last_run_at": (
+                    datetime.now(timezone.utc) - timedelta(hours=1)
+                ).isoformat(),
+            },
+        )
+        runs = self._claim(integration)
+        self.assertEqual(runs, [integration])
+        config = integration.config
+        self.assertEqual(config["quick_import_status"], "in_progress")
+        self.assertEqual(config["quick_import_queue"], ["trakt"])
+        self.assertEqual(config[QUICK_IMPORT_LEASE_OWNER_KEY], WORKER_A)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The quick import schedule previously bottomed out at 6 hours. This adds shorter intervals and hardens the scheduling so frequent syncs are safe.

- **30 min / 1 hour intervals**: new options in the quick import schedule dropdown (backend already accepts any positive interval, no API change).
- **Non-blocking**: unchanged by design — quick import runs in its own worker mode task, claims use short transactions with `FOR UPDATE SKIP LOCKED`, and each loop iteration processes a single provider. The lease check is a config-field comparison, no waiting.
- **Single-flight**: claims now stamp a 10-minute lease (`owner` = worker instance id) into the integration config; runs whose live lease belongs to another worker are skipped. Previously, with `LIBRARYSYNC_WORKER_QUICK_IMPORT_CONCURRENCY > 1` or multiple replicas, two workers could claim the same in-progress run and duplicate provider imports.
- **Self-heal**: if a worker crashes or hangs mid-run, its lease expires after 10 minutes and any worker reclaims the run, resuming from the persisted queue index — no restart from zero. The lease is refreshed at every claim (the loop's natural heartbeat) and cleared on completion/failure.

## Changes

- `core/import_control.py` — lease keys + helpers (`quick_import_lease_blocked`, `mark_quick_import_lease`, `clear_quick_import_lease`); lease cleared in `mark_quick_import_completed`/`mark_quick_import_failed`
- `jobs/imports.py` — lease-aware claiming in `_claim_quick_import_runs`
- `templates/settings/imports.html` — new interval options
- `backend/tests/test_quick_import_lease.py` — 12 tests: lease blocking rules, lease cleared on complete/fail, single-flight skip, stuck-run resume with index preserved
- `AGENTS.md` — documented the lease behavior under the `quick_import` job

## Validation

- Full backend suite: **224 passed** (212 existing + 12 new)
- `ruff check` clean on all touched files