### PR TITLE
Add mark-next-episode action and dashboard Up Next section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,14 +9,14 @@
 ## 2) Feature Set
 
 - **Authentication**: Multi-user JWT cookies with optional registration toggle
-- **History Management**: Manual add, update, delete, bulk delete; optional deletion in integrations
+- **History Management**: Manual add, update, delete, bulk delete; optional deletion in integrations; mark next released episode of a show as watched
 - **Ratings**: 0.5–5.0 star ratings synced to supported providers
 - **Metadata Providers**: TMDB, TVDB, IMDb, TVMaze, Kitsu, MyAnimeList (per-user configuration)
 - **Metadata Pipeline**: Async lookup and enrichment (posters/IDs) with local cache reuse
 - **Import Sources**: Trakt, SIMKL, Letterboxd, Stremio (quick import and full import)
 - **Import Queue**: Priority-ordered per-user queue with post-import deduplication
 - **Sync Engine**: Outbox-based delivery with retries, per-user rate limiting, and configurable batch sizes
-- **UI**: Minimal static HTML/JS interface (login, integrations, settings, activity, history)
+- **UI**: Minimal static HTML/JS interface (login, integrations, settings, activity, history, dashboard with up-next shows)
 
 ---
 
@@ -75,6 +75,7 @@ librarySync/
         metadata_lookup_engine.py
         metadata_enrichment.py
         metadata_providers.py
+        next_episode.py
         rate_limiter.py
         ratings.py
         security.py
@@ -256,6 +257,13 @@ DELETE /api/history/items
 DELETE /api/history/items/{watched_id}
 POST   /api/history/items/bulk-delete
 POST   /api/history/items/sync
+POST   /api/history/shows/{media_item_id}/mark-next-episode
+```
+
+### Dashboard
+```
+GET    /api/dashboard/stats
+GET    /api/dashboard/up-next
 ```
 
 ### Activity / Status

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -40,4 +40,4 @@ librarysync = [
 ]
 
 [dependency-groups]
-dev = ["ruff>=0.15.3", "pytest>=9.0.3", "pytest-asyncio>=0.23.0"]
+dev = ["ruff>=0.15.3", "pytest>=9.0.3", "pytest-asyncio>=0.23.0", "aiosqlite>=0.20.0"]

--- a/backend/src/librarysync/api/routes_dashboard.py
+++ b/backend/src/librarysync/api/routes_dashboard.py
@@ -25,9 +25,13 @@ def order_up_next_items(items: list[dict]) -> list[dict]:
     binging stays on top, and a new episode for a recently watched show ranks
     above one for a show not watched in a long time.
     """
-    items.sort(key=lambda item: item["last_watched_at"], reverse=True)
-    items.sort(key=lambda item: item["is_new_release"])
-    return items
+    return sorted(
+        items,
+        key=lambda item: (
+            item["is_new_release"],
+            -item["last_watched_at"].timestamp(),
+        ),
+    )
 
 
 @router.get(

--- a/backend/src/librarysync/api/routes_dashboard.py
+++ b/backend/src/librarysync/api/routes_dashboard.py
@@ -1,18 +1,98 @@
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import text
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from librarysync.api.deps import get_current_user, get_db
 from librarysync.config import settings
-from librarysync.db.models import User
+from librarysync.core.next_episode import episode_to_payload, find_next_episodes_bulk
+from librarysync.db.models import EpisodeItem, MediaItem, User, WatchedItem
 
 router = APIRouter(
     prefix="/api/dashboard",
     tags=["dashboard"],
     dependencies=[Depends(get_current_user)],
 )
+
+UP_NEXT_CANDIDATE_LIMIT = 60
+
+
+def order_up_next_items(items: list[dict]) -> list[dict]:
+    """Order items: continue watching first, then newly released episodes.
+
+    Each group is ordered by most recently watched, so a show the user is
+    binging stays on top, and a new episode for a recently watched show ranks
+    above one for a show not watched in a long time.
+    """
+    items.sort(key=lambda item: item["last_watched_at"], reverse=True)
+    items.sort(key=lambda item: item["is_new_release"])
+    return items
+
+
+@router.get(
+    "/up-next",
+    summary="Get up-next shows",
+    description="Shows with a released, unwatched next episode, ordered for binge continuation.",
+)
+async def get_up_next(
+    limit: int = Query(12, ge=1, le=50),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    now_date = datetime.now(timezone.utc).date()
+    last_watched_subq = (
+        select(
+            EpisodeItem.show_media_item_id.label("media_item_id"),
+            func.max(WatchedItem.watched_at).label("last_watched_at"),
+        )
+        .select_from(WatchedItem)
+        .join(EpisodeItem, WatchedItem.episode_item_id == EpisodeItem.id)
+        .where(
+            WatchedItem.user_id == current_user.id,
+            EpisodeItem.season_number > 0,
+        )
+        .group_by(EpisodeItem.show_media_item_id)
+        .order_by(func.max(WatchedItem.watched_at).desc())
+        .limit(UP_NEXT_CANDIDATE_LIMIT)
+        .subquery()
+    )
+    result = await db.execute(
+        select(last_watched_subq.c.media_item_id, last_watched_subq.c.last_watched_at)
+    )
+    rows = result.all()
+    if not rows:
+        return {"items": []}
+    show_ids = [row.media_item_id for row in rows]
+    next_episodes = await find_next_episodes_bulk(db, current_user.id, show_ids, now_date)
+    if not next_episodes:
+        return {"items": []}
+    media_result = await db.execute(
+        select(MediaItem).where(MediaItem.id.in_(list(next_episodes.keys())))
+    )
+    media_by_id = {media.id: media for media in media_result.scalars().all()}
+    items = []
+    for row in rows:
+        episode = next_episodes.get(row.media_item_id)
+        media = media_by_id.get(row.media_item_id)
+        if not episode or not media:
+            continue
+        is_new_release = bool(
+            episode.air_date and episode.air_date > row.last_watched_at.date()
+        )
+        items.append(
+            {
+                "media_item_id": media.id,
+                "title": media.title,
+                "year": media.year,
+                "media_type": media.media_type,
+                "poster_url": media.poster_url,
+                "last_watched_at": row.last_watched_at,
+                "is_new_release": is_new_release,
+                "next_episode": episode_to_payload(episode),
+            }
+        )
+    return {"items": order_up_next_items(items)[:limit]}
 
 
 @router.get(

--- a/backend/src/librarysync/api/routes_history.py
+++ b/backend/src/librarysync/api/routes_history.py
@@ -17,6 +17,7 @@ from librarysync.core.catalog_ordering import (
 from librarysync.core.next_episode import (
     SHOW_MEDIA_TYPES,
     episode_to_payload,
+    find_next_episode,
     find_next_episodes_bulk,
     mark_next_episode_watched,
 )
@@ -654,13 +655,15 @@ async def mark_show_next_episode_watched(
         watched, episode = await mark_next_episode_watched(db, current_user.id, media_item)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    next_episode = await find_next_episode(db, current_user.id, media_item.id)
     await db.commit()
     return {
         "watched_id": watched.id,
         "media_item_id": media_item.id,
         "episode_item_id": episode.id,
         "added_episode": f"S{episode.season_number:02d}E{episode.episode_number:02d}",
-        "next_episode": episode_to_payload(episode),
+        "marked_episode": episode_to_payload(episode),
+        "next_episode": episode_to_payload(next_episode) if next_episode else None,
     }
 
 

--- a/backend/src/librarysync/api/routes_history.py
+++ b/backend/src/librarysync/api/routes_history.py
@@ -14,6 +14,12 @@ from librarysync.core.catalog_ordering import (
     CatalogOrderDirection,
     apply_catalog_ordering,
 )
+from librarysync.core.next_episode import (
+    SHOW_MEDIA_TYPES,
+    episode_to_payload,
+    find_next_episodes_bulk,
+    mark_next_episode_watched,
+)
 from librarysync.core.ratings import normalize_star_rating
 from librarysync.core.watch_pipeline import (
     SYNC_COORDINATOR,
@@ -614,11 +620,47 @@ async def list_watched_items(
                 metadata=metadata,
             ).model_dump()
         )
+    merged_items = _merge_history_items(items)
+    await _attach_next_episodes(db, current_user.id, merged_items)
     return {
-        "items": _merge_history_items(items),
+        "items": merged_items,
         "limit": limit,
         "offset": offset,
         "total": total,
+    }
+
+
+@router.post(
+    "/shows/{media_item_id}/mark-next-episode",
+    status_code=status.HTTP_201_CREATED,
+    summary="Mark next episode as watched",
+    description="Record a watched entry for the next released, unwatched episode of a show.",
+)
+async def mark_show_next_episode_watched(
+    media_item_id: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    result = await db.execute(select(MediaItem).where(MediaItem.id == media_item_id))
+    media_item = result.scalars().first()
+    if not media_item:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Media item not found")
+    if media_item.media_type not in SHOW_MEDIA_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Next episode tracking is only available for shows",
+        )
+    try:
+        watched, episode = await mark_next_episode_watched(db, current_user.id, media_item)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    await db.commit()
+    return {
+        "watched_id": watched.id,
+        "media_item_id": media_item.id,
+        "episode_item_id": episode.id,
+        "added_episode": f"S{episode.season_number:02d}E{episode.episode_number:02d}",
+        "next_episode": episode_to_payload(episode),
     }
 
 
@@ -1200,6 +1242,26 @@ async def _is_rewatch(
         )
         return result.scalars().first() is not None
     return False
+
+
+async def _attach_next_episodes(
+    db: AsyncSession, user_id: str, items: list[dict]
+) -> None:
+    """Attach the next released, unwatched episode to show items, in place."""
+    show_ids: list[str] = []
+    for item in items:
+        if item.get("media_type") not in SHOW_MEDIA_TYPES:
+            continue
+        metadata = item.get("metadata") or {}
+        show_id = metadata.get("media_item_id")
+        if show_id:
+            show_ids.append(show_id)
+    next_episodes = await find_next_episodes_bulk(db, user_id, show_ids) if show_ids else {}
+    for item in items:
+        metadata = item.get("metadata") or {}
+        show_id = metadata.get("media_item_id")
+        episode = next_episodes.get(show_id) if show_id else None
+        item["next_episode"] = episode_to_payload(episode) if episode else None
 
 
 def _merge_history_items(items: list[dict]) -> list[dict]:

--- a/backend/src/librarysync/api/routes_watchlist.py
+++ b/backend/src/librarysync/api/routes_watchlist.py
@@ -16,7 +16,7 @@ from librarysync.core.catalog_ordering import (
     CatalogOrderDirection,
     apply_catalog_ordering,
 )
-from librarysync.core.next_episode import find_next_episode, has_released_episodes
+from librarysync.core.next_episode import SHOW_MEDIA_TYPES, find_next_episode, has_released_episodes
 from librarysync.core.publicmetadb import is_publicmetadb_sync_enabled
 from librarysync.core.watch_pipeline import enqueue_new_item_job
 from librarysync.core.watchlist import (
@@ -898,7 +898,7 @@ async def mark_watchlist_item_watched(
     target_media = media_item
     target_episode: EpisodeItem | None = None
 
-    if media_item.media_type == "tv":
+    if media_item.media_type in SHOW_MEDIA_TYPES:
         # Find the first released, unwatched episode
         target_episode = await find_next_episode(db, current_user.id, media_item.id)
         if not target_episode:

--- a/backend/src/librarysync/api/routes_watchlist.py
+++ b/backend/src/librarysync/api/routes_watchlist.py
@@ -16,6 +16,7 @@ from librarysync.core.catalog_ordering import (
     CatalogOrderDirection,
     apply_catalog_ordering,
 )
+from librarysync.core.next_episode import find_next_episode, has_released_episodes
 from librarysync.core.publicmetadb import is_publicmetadb_sync_enabled
 from librarysync.core.watch_pipeline import enqueue_new_item_job
 from librarysync.core.watchlist import (
@@ -898,49 +899,14 @@ async def mark_watchlist_item_watched(
     target_episode: EpisodeItem | None = None
 
     if media_item.media_type == "tv":
-        # Logic to find next episode:
-        # a) Get all released episodes
-        now_date = datetime.now(timezone.utc).date()
-        episodes_result = await db.execute(
-            select(EpisodeItem)
-            .where(
-                EpisodeItem.show_media_item_id == media_item.id,
-                EpisodeItem.air_date is not None,
-                EpisodeItem.air_date <= now_date,
-                EpisodeItem.season_number > 0,  # Exclude specials (season 0)
-            )
-            .order_by(EpisodeItem.season_number, EpisodeItem.episode_number)
-        )
-        released_episodes = episodes_result.scalars().all()
-        if not released_episodes:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="No released episodes found for this show",
-            )
-
-        # b) Get watched episodes
-        # Use a JOIN to properly filter watched episodes for this show
-        watched_result = await db.execute(
-            select(WatchedItem.episode_item_id)
-            .join(EpisodeItem, WatchedItem.episode_item_id == EpisodeItem.id)
-            .where(
-                WatchedItem.user_id == current_user.id,
-                WatchedItem.media_item_id.is_(None),
-                EpisodeItem.show_media_item_id == media_item.id,
-                EpisodeItem.air_date.is_not(None),
-                EpisodeItem.air_date <= now_date,
-                EpisodeItem.season_number > 0,
-            )
-        )
-        watched_episode_ids = set(watched_result.scalars().all())
-
-        # c) Find first unwatched
-        for ep in released_episodes:
-            if ep.id not in watched_episode_ids:
-                target_episode = ep
-                break
-
+        # Find the first released, unwatched episode
+        target_episode = await find_next_episode(db, current_user.id, media_item.id)
         if not target_episode:
+            if not await has_released_episodes(db, media_item.id):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="No released episodes found for this show",
+                )
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="All released episodes are already watched",

--- a/backend/src/librarysync/core/next_episode.py
+++ b/backend/src/librarysync/core/next_episode.py
@@ -1,0 +1,186 @@
+"""Helpers for finding and marking the next unwatched episode of a show."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Iterable, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from librarysync.core.watch_pipeline import enqueue_new_item_job
+from librarysync.db.models import EpisodeItem, MediaItem, WatchedItem, WatchEvent
+
+SHOW_MEDIA_TYPES = ("tv", "anime")
+
+
+def select_next_episode(
+    released_episodes: Iterable[EpisodeItem],
+    watched_episode_ids: set[str],
+) -> EpisodeItem | None:
+    """Return the first episode not in ``watched_episode_ids``.
+
+    ``released_episodes`` must already be ordered by season/episode number.
+    """
+    for episode in released_episodes:
+        if episode.id not in watched_episode_ids:
+            return episode
+    return None
+
+
+def episode_to_payload(episode: EpisodeItem) -> dict:
+    return {
+        "episode_item_id": episode.id,
+        "season_number": episode.season_number,
+        "episode_number": episode.episode_number,
+        "title": episode.title,
+        "air_date": episode.air_date.isoformat() if episode.air_date else None,
+    }
+
+
+async def _released_episodes(
+    db: AsyncSession,
+    show_media_item_ids: Sequence[str],
+    now_date: date,
+) -> list[EpisodeItem]:
+    result = await db.execute(
+        select(EpisodeItem)
+        .where(
+            EpisodeItem.show_media_item_id.in_(show_media_item_ids),
+            EpisodeItem.air_date.is_not(None),
+            EpisodeItem.air_date <= now_date,
+            EpisodeItem.season_number > 0,  # Exclude specials (season 0)
+        )
+        .order_by(
+            EpisodeItem.show_media_item_id,
+            EpisodeItem.season_number,
+            EpisodeItem.episode_number,
+        )
+    )
+    return list(result.scalars().all())
+
+
+async def _watched_episode_ids(
+    db: AsyncSession,
+    user_id: str,
+    show_media_item_ids: Sequence[str],
+    now_date: date,
+) -> set[str]:
+    result = await db.execute(
+        select(WatchedItem.episode_item_id)
+        .join(EpisodeItem, WatchedItem.episode_item_id == EpisodeItem.id)
+        .where(
+            WatchedItem.user_id == user_id,
+            WatchedItem.media_item_id.is_(None),
+            EpisodeItem.show_media_item_id.in_(show_media_item_ids),
+            EpisodeItem.air_date.is_not(None),
+            EpisodeItem.air_date <= now_date,
+            EpisodeItem.season_number > 0,
+        )
+    )
+    return set(result.scalars().all())
+
+
+async def find_next_episode(
+    db: AsyncSession,
+    user_id: str,
+    show_media_item_id: str,
+    now_date: date | None = None,
+) -> EpisodeItem | None:
+    """Return the first released, unwatched episode for a show, if any."""
+    next_episodes = await find_next_episodes_bulk(db, user_id, [show_media_item_id], now_date)
+    return next_episodes.get(show_media_item_id)
+
+
+async def find_next_episodes_bulk(
+    db: AsyncSession,
+    user_id: str,
+    show_media_item_ids: Sequence[str],
+    now_date: date | None = None,
+) -> dict[str, EpisodeItem]:
+    """Return the first released, unwatched episode per show."""
+    show_ids = list(dict.fromkeys(show_media_item_ids))
+    if not show_ids:
+        return {}
+    now_date = now_date or datetime.now(timezone.utc).date()
+    released = await _released_episodes(db, show_ids, now_date)
+    watched_ids = await _watched_episode_ids(db, user_id, show_ids, now_date)
+    next_episodes: dict[str, EpisodeItem] = {}
+    for episode in released:
+        if episode.show_media_item_id in next_episodes:
+            continue
+        if episode.id in watched_ids:
+            continue
+        next_episodes[episode.show_media_item_id] = episode
+    return next_episodes
+
+
+async def has_released_episodes(
+    db: AsyncSession,
+    show_media_item_id: str,
+    now_date: date | None = None,
+) -> bool:
+    now_date = now_date or datetime.now(timezone.utc).date()
+    result = await db.execute(
+        select(EpisodeItem.id)
+        .where(
+            EpisodeItem.show_media_item_id == show_media_item_id,
+            EpisodeItem.air_date.is_not(None),
+            EpisodeItem.air_date <= now_date,
+            EpisodeItem.season_number > 0,
+        )
+        .limit(1)
+    )
+    return result.scalars().first() is not None
+
+
+async def mark_next_episode_watched(
+    db: AsyncSession,
+    user_id: str,
+    media_item: MediaItem,
+    *,
+    source: str = "manual",
+    watched_at: datetime | None = None,
+    event_raw_extra: dict | None = None,
+) -> tuple[WatchedItem, EpisodeItem]:
+    """Record a watched entry for the next released, unwatched episode of a show.
+
+    Raises ValueError when the media item is not a show or no released,
+    unwatched episode exists. Does not commit; the caller owns the transaction.
+    """
+    if media_item.media_type not in SHOW_MEDIA_TYPES:
+        raise ValueError("Next episode tracking is only available for shows")
+    next_episode = await find_next_episode(db, user_id, media_item.id)
+    if not next_episode:
+        raise ValueError("No released, unwatched episode found for this show")
+    watched_at = watched_at or datetime.now(timezone.utc)
+    watched = WatchedItem(
+        user_id=user_id,
+        media_item_id=None,
+        episode_item_id=next_episode.id,
+        watched_at=watched_at,
+        source=source,
+    )
+    event_raw: dict = {
+        "source": source,
+        "episode": {
+            "season_number": next_episode.season_number,
+            "episode_number": next_episode.episode_number,
+            "title": next_episode.title,
+            "id": next_episode.id,
+        },
+    }
+    if event_raw_extra:
+        event_raw.update(event_raw_extra)
+    event = WatchEvent(
+        user_id=user_id,
+        media_item_id=None,
+        episode_item_id=next_episode.id,
+        event_type="manual_watched",
+        occurred_at=watched_at,
+        raw=event_raw,
+    )
+    db.add_all([watched, event])
+    await db.flush()
+    await enqueue_new_item_job(db, user_id, watched.id, is_rewatch=False, source=source)
+    return watched, next_episode

--- a/backend/src/librarysync/static/page-history.js
+++ b/backend/src/librarysync/static/page-history.js
@@ -732,6 +732,10 @@ async function loadHistory() {
     deleteButton.setAttribute("role", "menuitem");
 
     menuPanel.appendChild(editButton);
+    const markNextButton = buildMarkNextEpisodeButton(item);
+    if (markNextButton) {
+      menuPanel.appendChild(markNextButton);
+    }
     if (item.media_type === "tv" || item.media_type === "anime") {
       menuPanel.appendChild(addToWatchlistButton);
     }
@@ -879,6 +883,38 @@ async function loadHistory() {
     card.appendChild(meta);
     container.appendChild(card);
   });
+}
+
+function buildMarkNextEpisodeButton(item) {
+  if (!item.next_episode || !item.metadata || !item.metadata.media_item_id) {
+    return null;
+  }
+  const episodeLabel = formatSeasonEpisode(
+    item.next_episode.season_number,
+    item.next_episode.episode_number,
+  );
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = episodeLabel
+    ? `Mark ${episodeLabel} watched`
+    : "Mark next episode watched";
+  button.setAttribute("role", "menuitem");
+  button.addEventListener("click", async () => {
+    closeHistoryMenus();
+    try {
+      setMessage("history-message", "Marking episode as watched...");
+      const data = await requestJSON(
+        `/api/history/shows/${item.metadata.media_item_id}/mark-next-episode`,
+        { method: "POST" },
+      );
+      const added = data && data.added_episode ? data.added_episode : episodeLabel;
+      setMessage("history-message", `Marked ${added || "episode"} as watched.`);
+      await loadHistory();
+    } catch (error) {
+      setMessage("history-message", error.message, true);
+    }
+  });
+  return button;
 }
 
 function buildRatingSelect(currentValue) {

--- a/backend/src/librarysync/static/page-home.js
+++ b/backend/src/librarysync/static/page-home.js
@@ -4,7 +4,13 @@ const dashboardState = {
     breakdown: null,
     ratings: null,
   },
+  upNext: {
+    items: [],
+    visibleCount: 5,
+  },
 };
+
+const UP_NEXT_PAGE_SIZE = 5;
 
 function renderHomeStatus(statusData) {
   const pendingEl = document.getElementById("home-outbox-pending");
@@ -81,151 +87,200 @@ async function loadUpNext() {
     return;
   }
   try {
-    const data = await requestJSON("/api/dashboard/up-next?limit=12");
+    const data = await requestJSON("/api/dashboard/up-next?limit=50");
     const items = data && data.items ? data.items : [];
-    renderUpNext(items);
+    // Reset to first page on every fresh load
+    dashboardState.upNext.items = items;
+    dashboardState.upNext.visibleCount = UP_NEXT_PAGE_SIZE;
+    renderUpNext();
   } catch (error) {
     console.error("Failed to load up next", error);
   }
 }
 
-function renderUpNext(items) {
+function buildUpNextRow(item) {
+  const nextEpisode = item.next_episode || {};
+  const episodeLabel = formatSeasonEpisode(
+    nextEpisode.season_number,
+    nextEpisode.episode_number,
+  );
+
+  const row = document.createElement("div");
+  row.className = "up-next-row";
+
+  // Thumbnail
+  const thumb = document.createElement("img");
+  thumb.className = "up-next-thumb";
+  if (item.poster_url) {
+    thumb.src = item.poster_url;
+    thumb.alt = `${item.title} poster`;
+    thumb.loading = "lazy";
+  } else {
+    thumb.alt = "";
+  }
+
+  // Body
+  const body = document.createElement("div");
+  body.className = "up-next-body";
+
+  // Title row: show name + episode code + new badge
+  const titleRow = document.createElement("div");
+  titleRow.className = "up-next-title-row";
+
+  const titleEl = document.createElement("span");
+  titleEl.className = "up-next-title";
+  titleEl.textContent = item.title;
+  titleRow.appendChild(titleEl);
+
+  if (episodeLabel) {
+    const epEl = document.createElement("span");
+    epEl.className = "up-next-episode";
+    epEl.textContent = episodeLabel;
+    titleRow.appendChild(epEl);
+  }
+
+  if (item.is_new_release) {
+    const badge = document.createElement("span");
+    badge.className = "up-next-new-badge";
+    badge.textContent = "New";
+    titleRow.appendChild(badge);
+  }
+
+  // Meta line: episode title · aired date
+  const metaParts = [];
+  if (nextEpisode.title) {
+    metaParts.push(nextEpisode.title);
+  }
+  if (nextEpisode.air_date) {
+    metaParts.push(`Aired ${formatReleaseDate(nextEpisode.air_date)}`);
+  } else if (item.year && !episodeLabel) {
+    metaParts.push(String(item.year));
+  }
+
+  const metaEl = document.createElement("p");
+  metaEl.className = "up-next-meta";
+  metaEl.textContent = metaParts.join(" · ");
+
+  body.appendChild(titleRow);
+  body.appendChild(metaEl);
+
+  // Action button
+  const action = document.createElement("div");
+  action.className = "up-next-action";
+
+  const markButton = document.createElement("button");
+  markButton.type = "button";
+  markButton.className = "btn btn-primary btn-xs";
+  markButton.setAttribute(
+    "aria-label",
+    episodeLabel
+      ? `Mark ${item.title} ${episodeLabel} as watched`
+      : `Mark ${item.title} as watched`,
+  );
+  markButton.setAttribute(
+    "title",
+    episodeLabel ? `Mark ${episodeLabel} watched` : "Mark watched",
+  );
+
+  const svgNS = "http://www.w3.org/2000/svg";
+  const svg = document.createElementNS(svgNS, "svg");
+  svg.setAttribute("width", "12");
+  svg.setAttribute("height", "12");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", "2.5");
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  svg.setAttribute("aria-hidden", "true");
+  const polyline = document.createElementNS(svgNS, "polyline");
+  polyline.setAttribute("points", "20 6 9 17 4 12");
+  svg.appendChild(polyline);
+
+  const btnLabel = document.createElement("span");
+  btnLabel.textContent = "Watched";
+
+  markButton.appendChild(svg);
+  markButton.appendChild(btnLabel);
+
+  markButton.addEventListener("click", async () => {
+    markButton.disabled = true;
+    try {
+      const data = await requestJSON(
+        `/api/history/shows/${item.media_item_id}/mark-next-episode`,
+        { method: "POST" },
+      );
+      const added = data && data.added_episode ? data.added_episode : episodeLabel;
+      showToast(`Marked ${added || "episode"} as watched.`);
+      await Promise.all([loadUpNext(), loadDashboardStats()]);
+    } catch (error) {
+      showToast(error.message, true);
+      markButton.disabled = false;
+    }
+  });
+  action.appendChild(markButton);
+
+  row.appendChild(thumb);
+  row.appendChild(body);
+  row.appendChild(action);
+  return row;
+}
+
+function renderUpNext() {
   const section = document.getElementById("up-next-section");
   const container = document.getElementById("up-next-list");
+  const footer = document.getElementById("up-next-footer");
   if (!section || !container) {
     return;
   }
-  if (!items.length) {
+
+  const { items, visibleCount } = dashboardState.upNext;
+  const total = items.length;
+
+  if (!total) {
     section.hidden = true;
     container.innerHTML = "";
+    if (footer) {
+      footer.hidden = true;
+    }
     return;
   }
+
   section.hidden = false;
   container.innerHTML = "";
-  items.forEach((item) => {
-    const nextEpisode = item.next_episode || {};
-    const episodeLabel = formatSeasonEpisode(
-      nextEpisode.season_number,
-      nextEpisode.episode_number,
-    );
 
-    // Row container
-    const row = document.createElement("div");
-    row.className = "up-next-row";
-
-    // Thumbnail
-    const thumb = document.createElement("img");
-    thumb.className = "up-next-thumb";
-    if (item.poster_url) {
-      thumb.src = item.poster_url;
-      thumb.alt = `${item.title} poster`;
-      thumb.loading = "lazy";
-    } else {
-      thumb.alt = "";
-    }
-
-    // Body
-    const body = document.createElement("div");
-    body.className = "up-next-body";
-
-    // Title row: show name + episode code + new badge
-    const titleRow = document.createElement("div");
-    titleRow.className = "up-next-title-row";
-
-    const titleEl = document.createElement("span");
-    titleEl.className = "up-next-title";
-    titleEl.textContent = item.title;
-    titleRow.appendChild(titleEl);
-
-    if (episodeLabel) {
-      const epEl = document.createElement("span");
-      epEl.className = "up-next-episode";
-      epEl.textContent = episodeLabel;
-      titleRow.appendChild(epEl);
-    }
-
-    if (item.is_new_release) {
-      const badge = document.createElement("span");
-      badge.className = "up-next-new-badge";
-      badge.textContent = "New";
-      titleRow.appendChild(badge);
-    }
-
-    // Meta line: episode title · aired date
-    const metaParts = [];
-    if (nextEpisode.title) {
-      metaParts.push(nextEpisode.title);
-    }
-    if (nextEpisode.air_date) {
-      metaParts.push(`Aired ${formatReleaseDate(nextEpisode.air_date)}`);
-    } else if (item.year && !episodeLabel) {
-      metaParts.push(String(item.year));
-    }
-
-    const metaEl = document.createElement("p");
-    metaEl.className = "up-next-meta";
-    metaEl.textContent = metaParts.join(" · ");
-
-    body.appendChild(titleRow);
-    body.appendChild(metaEl);
-
-    // Action button — compact, icon+text on desktop, icon-only hint on mobile
-    const action = document.createElement("div");
-    action.className = "up-next-action";
-
-    const markButton = document.createElement("button");
-    markButton.type = "button";
-    markButton.className = "btn btn-primary btn-xs";
-    markButton.setAttribute(
-      "aria-label",
-      episodeLabel ? `Mark ${item.title} ${episodeLabel} as watched` : `Mark ${item.title} as watched`,
-    );
-    markButton.setAttribute("title", episodeLabel ? `Mark ${episodeLabel} watched` : "Mark watched");
-
-    // SVG check icon
-    const svgNS = "http://www.w3.org/2000/svg";
-    const svg = document.createElementNS(svgNS, "svg");
-    svg.setAttribute("width", "12");
-    svg.setAttribute("height", "12");
-    svg.setAttribute("viewBox", "0 0 24 24");
-    svg.setAttribute("fill", "none");
-    svg.setAttribute("stroke", "currentColor");
-    svg.setAttribute("stroke-width", "2.5");
-    svg.setAttribute("stroke-linecap", "round");
-    svg.setAttribute("stroke-linejoin", "round");
-    svg.setAttribute("aria-hidden", "true");
-    const polyline = document.createElementNS(svgNS, "polyline");
-    polyline.setAttribute("points", "20 6 9 17 4 12");
-    svg.appendChild(polyline);
-
-    const btnLabel = document.createElement("span");
-    btnLabel.textContent = "Watched";
-
-    markButton.appendChild(svg);
-    markButton.appendChild(btnLabel);
-
-    markButton.addEventListener("click", async () => {
-      markButton.disabled = true;
-      try {
-        const data = await requestJSON(
-          `/api/history/shows/${item.media_item_id}/mark-next-episode`,
-          { method: "POST" },
-        );
-        const added = data && data.added_episode ? data.added_episode : episodeLabel;
-        showToast(`Marked ${added || "episode"} as watched.`);
-        await Promise.all([loadUpNext(), loadDashboardStats()]);
-      } catch (error) {
-        showToast(error.message, true);
-        markButton.disabled = false;
-      }
-    });
-    action.appendChild(markButton);
-
-    row.appendChild(thumb);
-    row.appendChild(body);
-    row.appendChild(action);
-    container.appendChild(row);
+  const visible = items.slice(0, visibleCount);
+  visible.forEach((item) => {
+    container.appendChild(buildUpNextRow(item));
   });
+
+  // Footer: only shown when there are more than UP_NEXT_PAGE_SIZE items
+  if (footer) {
+    if (total <= UP_NEXT_PAGE_SIZE) {
+      footer.hidden = true;
+    } else {
+      footer.hidden = false;
+      renderUpNextFooter(footer, total);
+    }
+  }
+}
+
+function renderUpNextFooter(footer, total) {
+  const { visibleCount } = dashboardState.upNext;
+  const allShown = visibleCount >= total;
+
+  // Count label
+  const countEl = footer.querySelector(".up-next-count");
+  if (countEl) {
+    countEl.textContent = `Showing ${Math.min(visibleCount, total)} of ${total}`;
+  }
+
+  // Toggle button
+  const toggleBtn = footer.querySelector(".up-next-toggle");
+  if (toggleBtn) {
+    toggleBtn.textContent = allShown ? "Show less" : "Show more";
+    toggleBtn.setAttribute("aria-expanded", String(allShown));
+  }
 }
 
 async function loadHomeStatus() {
@@ -612,5 +667,26 @@ window.librarysyncPageInit = async ({ user }) => {
   if (!user) {
     return;
   }
+
+  // Wire up the Up Next show-more / show-less toggle (once, on page init)
+  const upNextFooterToggle = document.querySelector("#up-next-footer .up-next-toggle");
+  if (upNextFooterToggle) {
+    upNextFooterToggle.addEventListener("click", () => {
+      const { items, visibleCount } = dashboardState.upNext;
+      const total = items.length;
+      if (visibleCount >= total) {
+        // Collapse back to first page
+        dashboardState.upNext.visibleCount = UP_NEXT_PAGE_SIZE;
+      } else {
+        // Reveal next page
+        dashboardState.upNext.visibleCount = Math.min(
+          visibleCount + UP_NEXT_PAGE_SIZE,
+          total,
+        );
+      }
+      renderUpNext();
+    });
+  }
+
   await Promise.all([loadHomeStatus(), loadDashboardStats(), loadUpNext()]);
 };

--- a/backend/src/librarysync/static/page-home.js
+++ b/backend/src/librarysync/static/page-home.js
@@ -109,57 +109,101 @@ function renderUpNext(items) {
       nextEpisode.episode_number,
     );
 
-    const card = document.createElement("div");
-    card.className = "up-next-card";
+    // Row container
+    const row = document.createElement("div");
+    row.className = "up-next-row";
 
-    const poster = document.createElement("img");
-    poster.className = "candidate-poster";
+    // Thumbnail
+    const thumb = document.createElement("img");
+    thumb.className = "up-next-thumb";
     if (item.poster_url) {
-      poster.src = item.poster_url;
-      poster.alt = `${item.title} poster`;
-      poster.loading = "lazy";
+      thumb.src = item.poster_url;
+      thumb.alt = `${item.title} poster`;
+      thumb.loading = "lazy";
     } else {
-      poster.alt = "";
+      thumb.alt = "";
     }
 
-    const meta = document.createElement("div");
-    meta.className = "candidate-meta";
+    // Body
+    const body = document.createElement("div");
+    body.className = "up-next-body";
 
-    const header = document.createElement("div");
-    header.className = "history-header";
-    const title = document.createElement("h3");
-    title.textContent = item.title;
-    header.appendChild(title);
+    // Title row: show name + episode code + new badge
+    const titleRow = document.createElement("div");
+    titleRow.className = "up-next-title-row";
+
+    const titleEl = document.createElement("span");
+    titleEl.className = "up-next-title";
+    titleEl.textContent = item.title;
+    titleRow.appendChild(titleEl);
+
+    if (episodeLabel) {
+      const epEl = document.createElement("span");
+      epEl.className = "up-next-episode";
+      epEl.textContent = episodeLabel;
+      titleRow.appendChild(epEl);
+    }
+
     if (item.is_new_release) {
       const badge = document.createElement("span");
-      badge.className = "watchlist-pill";
-      badge.textContent = "New episode";
-      header.appendChild(badge);
+      badge.className = "up-next-new-badge";
+      badge.textContent = "New";
+      titleRow.appendChild(badge);
     }
 
-    const detail = document.createElement("p");
-    const detailParts = [];
-    if (item.year) {
-      detailParts.push(item.year);
-    }
-    if (episodeLabel) {
-      detailParts.push(
-        nextEpisode.title ? `${episodeLabel} · ${nextEpisode.title}` : episodeLabel,
-      );
+    // Meta line: episode title · aired date
+    const metaParts = [];
+    if (nextEpisode.title) {
+      metaParts.push(nextEpisode.title);
     }
     if (nextEpisode.air_date) {
-      detailParts.push(`Aired ${formatReleaseDate(nextEpisode.air_date)}`);
+      metaParts.push(`Aired ${formatReleaseDate(nextEpisode.air_date)}`);
+    } else if (item.year && !episodeLabel) {
+      metaParts.push(String(item.year));
     }
-    detail.textContent = detailParts.join(" · ");
 
-    const actions = document.createElement("div");
-    actions.className = "mt-2";
+    const metaEl = document.createElement("p");
+    metaEl.className = "up-next-meta";
+    metaEl.textContent = metaParts.join(" · ");
+
+    body.appendChild(titleRow);
+    body.appendChild(metaEl);
+
+    // Action button — compact, icon+text on desktop, icon-only hint on mobile
+    const action = document.createElement("div");
+    action.className = "up-next-action";
+
     const markButton = document.createElement("button");
     markButton.type = "button";
-    markButton.className = "btn btn-primary btn-sm";
-    markButton.textContent = episodeLabel
-      ? `Mark ${episodeLabel} watched`
-      : "Mark watched";
+    markButton.className = "btn btn-primary btn-xs";
+    markButton.setAttribute(
+      "aria-label",
+      episodeLabel ? `Mark ${item.title} ${episodeLabel} as watched` : `Mark ${item.title} as watched`,
+    );
+    markButton.setAttribute("title", episodeLabel ? `Mark ${episodeLabel} watched` : "Mark watched");
+
+    // SVG check icon
+    const svgNS = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(svgNS, "svg");
+    svg.setAttribute("width", "12");
+    svg.setAttribute("height", "12");
+    svg.setAttribute("viewBox", "0 0 24 24");
+    svg.setAttribute("fill", "none");
+    svg.setAttribute("stroke", "currentColor");
+    svg.setAttribute("stroke-width", "2.5");
+    svg.setAttribute("stroke-linecap", "round");
+    svg.setAttribute("stroke-linejoin", "round");
+    svg.setAttribute("aria-hidden", "true");
+    const polyline = document.createElementNS(svgNS, "polyline");
+    polyline.setAttribute("points", "20 6 9 17 4 12");
+    svg.appendChild(polyline);
+
+    const btnLabel = document.createElement("span");
+    btnLabel.textContent = "Watched";
+
+    markButton.appendChild(svg);
+    markButton.appendChild(btnLabel);
+
     markButton.addEventListener("click", async () => {
       markButton.disabled = true;
       try {
@@ -175,14 +219,12 @@ function renderUpNext(items) {
         markButton.disabled = false;
       }
     });
-    actions.appendChild(markButton);
+    action.appendChild(markButton);
 
-    meta.appendChild(header);
-    meta.appendChild(detail);
-    meta.appendChild(actions);
-    card.appendChild(poster);
-    card.appendChild(meta);
-    container.appendChild(card);
+    row.appendChild(thumb);
+    row.appendChild(body);
+    row.appendChild(action);
+    container.appendChild(row);
   });
 }
 

--- a/backend/src/librarysync/static/page-home.js
+++ b/backend/src/librarysync/static/page-home.js
@@ -74,6 +74,118 @@ function renderHomeStatus(statusData) {
   }
 }
 
+async function loadUpNext() {
+  const section = document.getElementById("up-next-section");
+  const container = document.getElementById("up-next-list");
+  if (!section || !container) {
+    return;
+  }
+  try {
+    const data = await requestJSON("/api/dashboard/up-next?limit=12");
+    const items = data && data.items ? data.items : [];
+    renderUpNext(items);
+  } catch (error) {
+    console.error("Failed to load up next", error);
+  }
+}
+
+function renderUpNext(items) {
+  const section = document.getElementById("up-next-section");
+  const container = document.getElementById("up-next-list");
+  if (!section || !container) {
+    return;
+  }
+  if (!items.length) {
+    section.hidden = true;
+    container.innerHTML = "";
+    return;
+  }
+  section.hidden = false;
+  container.innerHTML = "";
+  items.forEach((item) => {
+    const nextEpisode = item.next_episode || {};
+    const episodeLabel = formatSeasonEpisode(
+      nextEpisode.season_number,
+      nextEpisode.episode_number,
+    );
+
+    const card = document.createElement("div");
+    card.className = "up-next-card";
+
+    const poster = document.createElement("img");
+    poster.className = "candidate-poster";
+    if (item.poster_url) {
+      poster.src = item.poster_url;
+      poster.alt = `${item.title} poster`;
+      poster.loading = "lazy";
+    } else {
+      poster.alt = "";
+    }
+
+    const meta = document.createElement("div");
+    meta.className = "candidate-meta";
+
+    const header = document.createElement("div");
+    header.className = "history-header";
+    const title = document.createElement("h3");
+    title.textContent = item.title;
+    header.appendChild(title);
+    if (item.is_new_release) {
+      const badge = document.createElement("span");
+      badge.className = "watchlist-pill";
+      badge.textContent = "New episode";
+      header.appendChild(badge);
+    }
+
+    const detail = document.createElement("p");
+    const detailParts = [];
+    if (item.year) {
+      detailParts.push(item.year);
+    }
+    if (episodeLabel) {
+      detailParts.push(
+        nextEpisode.title ? `${episodeLabel} · ${nextEpisode.title}` : episodeLabel,
+      );
+    }
+    if (nextEpisode.air_date) {
+      detailParts.push(`Aired ${formatReleaseDate(nextEpisode.air_date)}`);
+    }
+    detail.textContent = detailParts.join(" · ");
+
+    const actions = document.createElement("div");
+    actions.className = "mt-2";
+    const markButton = document.createElement("button");
+    markButton.type = "button";
+    markButton.className = "btn btn-primary btn-sm";
+    markButton.textContent = episodeLabel
+      ? `Mark ${episodeLabel} watched`
+      : "Mark watched";
+    markButton.addEventListener("click", async () => {
+      markButton.disabled = true;
+      try {
+        const data = await requestJSON(
+          `/api/history/shows/${item.media_item_id}/mark-next-episode`,
+          { method: "POST" },
+        );
+        const added = data && data.added_episode ? data.added_episode : episodeLabel;
+        showToast(`Marked ${added || "episode"} as watched.`);
+        await Promise.all([loadUpNext(), loadDashboardStats()]);
+      } catch (error) {
+        showToast(error.message, true);
+        markButton.disabled = false;
+      }
+    });
+    actions.appendChild(markButton);
+
+    meta.appendChild(header);
+    meta.appendChild(detail);
+    meta.appendChild(actions);
+    card.appendChild(poster);
+    card.appendChild(meta);
+    container.appendChild(card);
+  });
+}
+
 async function loadHomeStatus() {
   const statusCard = document.getElementById("home-status");
   if (!statusCard) {
@@ -458,5 +570,5 @@ window.librarysyncPageInit = async ({ user }) => {
   if (!user) {
     return;
   }
-  await Promise.all([loadHomeStatus(), loadDashboardStats()]);
+  await Promise.all([loadHomeStatus(), loadDashboardStats(), loadUpNext()]);
 };

--- a/backend/src/librarysync/static/styles.css
+++ b/backend/src/librarysync/static/styles.css
@@ -53,6 +53,7 @@
     --font-weight-bold: 700;
     --tracking-tight: -0.025em;
     --tracking-wider: 0.05em;
+    --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
     --radius-xl: 1rem;
     --radius-2xl: 1.5rem;
@@ -723,6 +724,9 @@
   }
   .bg-clip-text {
     background-clip: text;
+  }
+  .\!p-0 {
+    padding: 0px !important;
   }
   .p-2 {
     padding: calc(var(--spacing) * 2);
@@ -2171,30 +2175,132 @@
     padding: calc(var(--spacing) * 4);
   }
   .up-next-list {
-    display: grid;
-    gap: calc(var(--spacing) * 4);
-    padding: calc(var(--spacing) * 4);
-    @media (width >= 40rem) {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+    :where(& > :not(:last-child)) {
+      --tw-divide-y-reverse: 0;
+      border-bottom-style: var(--tw-border-style);
+      border-top-style: var(--tw-border-style);
+      border-top-width: calc(1px * var(--tw-divide-y-reverse));
+      border-bottom-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+    }
+    :where(& > :not(:last-child)) {
+      border-color: color-mix(in srgb, rgb(214 223 230) 40%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        border-color: color-mix(in oklab, var(--color-line) 40%, transparent);
+      }
+    }
+    padding-inline: calc(var(--spacing) * 2);
+    padding-block: var(--spacing);
+  }
+  .up-next-row {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--spacing) * 3);
+    border-radius: var(--radius-xl);
+    padding-inline: calc(var(--spacing) * 3);
+    padding-block: calc(var(--spacing) * 2.5);
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+    &:hover {
+      @media (hover: hover) {
+        background-color: color-mix(in srgb, rgb(241 245 248) 40%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-elevated) 40%, transparent);
+        }
+      }
     }
   }
-  .up-next-card {
-    display: grid;
-    grid-template-columns: 64px,1fr;
+  .up-next-thumb {
+    height: 52px;
+    width: 36px;
+    flex: none;
+    border-radius: var(--radius-md);
+    background-color: var(--color-elevated);
+    object-fit: cover;
+    --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .up-next-body {
+    min-width: 0px;
+    flex: 1;
+  }
+  .up-next-title-row {
+    display: flex;
+    min-width: 0px;
     align-items: center;
-    gap: calc(var(--spacing) * 4);
+    gap: calc(var(--spacing) * 2);
+  }
+  .up-next-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+    --tw-leading: calc(var(--spacing) * 5);
+    line-height: calc(var(--spacing) * 5);
+    --tw-font-weight: var(--font-weight-semibold);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-ink);
+  }
+  .up-next-episode {
+    flex: none;
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-primary);
+  }
+  .up-next-meta {
+    margin-top: calc(var(--spacing) * 0.5);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+    --tw-leading: calc(var(--spacing) * 4);
+    line-height: calc(var(--spacing) * 4);
+    color: var(--color-muted);
+  }
+  .up-next-action {
+    flex: none;
+  }
+  .up-next-new-badge {
+    flex-shrink: 0;
+    border-radius: 999px;
+    background-color: color-mix(in srgb, rgb(13 120 211) 15%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in srgb, var(--color-primary) 15%, transparent);
+    }
+    color: var(--color-primary);
+    border: 1px solid color-mix(in srgb, rgb(13 120 211) 25%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border: 1px solid color-mix(in srgb, var(--color-primary) 25%, transparent);
+    }
+    padding: 0.1rem 0.45rem;
+    font-size: 0.6rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+  .up-next-card {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--spacing) * 3);
     border-radius: var(--radius-xl);
-    border-style: var(--tw-border-style);
-    border-width: 1px;
-    border-color: color-mix(in srgb, rgb(214 223 230) 70%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      border-color: color-mix(in oklab, var(--color-line) 70%, transparent);
+    padding-inline: calc(var(--spacing) * 3);
+    padding-block: calc(var(--spacing) * 2.5);
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+    &:hover {
+      @media (hover: hover) {
+        background-color: color-mix(in srgb, rgb(241 245 248) 40%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-elevated) 40%, transparent);
+        }
+      }
     }
-    background-color: color-mix(in srgb, rgb(255 255 255) 70%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-surface) 70%, transparent);
-    }
-    padding: calc(var(--spacing) * 4);
   }
   .history-card.is-watched {
     border-color: color-mix(in srgb, rgb(214 223 230) 50%, transparent);
@@ -3510,6 +3616,11 @@
   inherits: false;
   initial-value: 1;
 }
+@property --tw-divide-y-reverse {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
 @layer properties {
   @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
     *, ::before, ::after, ::backdrop {
@@ -3571,6 +3682,7 @@
       --tw-scale-x: 1;
       --tw-scale-y: 1;
       --tw-scale-z: 1;
+      --tw-divide-y-reverse: 0;
     }
   }
 }

--- a/backend/src/librarysync/static/styles.css
+++ b/backend/src/librarysync/static/styles.css
@@ -231,6 +231,9 @@
   .pointer-events-none {
     pointer-events: none;
   }
+  .visible {
+    visibility: visible;
+  }
   .absolute {
     position: absolute;
   }
@@ -2282,6 +2285,54 @@
     letter-spacing: 0.08em;
     text-transform: uppercase;
     white-space: nowrap;
+  }
+  .up-next-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-top-style: var(--tw-border-style);
+    border-top-width: 1px;
+    border-color: color-mix(in srgb, rgb(214 223 230) 40%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-line) 40%, transparent);
+    }
+    padding-inline: calc(var(--spacing) * 5);
+    padding-block: calc(var(--spacing) * 2.5);
+  }
+  .up-next-count {
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+    color: var(--color-muted);
+  }
+  .up-next-toggle {
+    border-radius: 0.25rem;
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-primary);
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-accent);
+      }
+    }
+    &:focus-visible {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+    &:focus-visible {
+      --tw-ring-color: color-mix(in srgb, rgb(13 120 211) 40%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        --tw-ring-color: color-mix(in oklab, var(--color-primary) 40%, transparent);
+      }
+    }
+    &:focus-visible {
+      --tw-outline-style: none;
+      outline-style: none;
+    }
   }
   .up-next-card {
     display: flex;

--- a/backend/src/librarysync/static/styles.css
+++ b/backend/src/librarysync/static/styles.css
@@ -2170,6 +2170,32 @@
     }
     padding: calc(var(--spacing) * 4);
   }
+  .up-next-list {
+    display: grid;
+    gap: calc(var(--spacing) * 4);
+    padding: calc(var(--spacing) * 4);
+    @media (width >= 40rem) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  .up-next-card {
+    display: grid;
+    grid-template-columns: 64px,1fr;
+    align-items: center;
+    gap: calc(var(--spacing) * 4);
+    border-radius: var(--radius-xl);
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+    border-color: color-mix(in srgb, rgb(214 223 230) 70%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-line) 70%, transparent);
+    }
+    background-color: color-mix(in srgb, rgb(255 255 255) 70%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-surface) 70%, transparent);
+    }
+    padding: calc(var(--spacing) * 4);
+  }
   .history-card.is-watched {
     border-color: color-mix(in srgb, rgb(214 223 230) 50%, transparent);
     @supports (color: color-mix(in lab, red, red)) {

--- a/backend/src/librarysync/templates/index.html
+++ b/backend/src/librarysync/templates/index.html
@@ -125,9 +125,9 @@
   </section>
 
   <!-- Up Next -->
-  <section id="up-next-section" class="card" hidden>
-    <div class="card-header flex items-center justify-between border-b border-line/40 px-6 py-4">
-      <h3 class="font-display font-semibold text-ink">Up Next</h3>
+  <section id="up-next-section" class="card !p-0 overflow-hidden" hidden>
+    <div class="flex items-center justify-between px-5 py-3 border-b border-line/40">
+      <h3 class="font-display text-sm font-semibold text-ink">Up Next</h3>
       <a href="/history" class="text-xs font-medium text-primary hover:text-accent">View History</a>
     </div>
     <div id="up-next-list" class="up-next-list"></div>

--- a/backend/src/librarysync/templates/index.html
+++ b/backend/src/librarysync/templates/index.html
@@ -124,6 +124,15 @@
     </div>
   </section>
 
+  <!-- Up Next -->
+  <section id="up-next-section" class="card" hidden>
+    <div class="card-header flex items-center justify-between border-b border-line/40 px-6 py-4">
+      <h3 class="font-display font-semibold text-ink">Up Next</h3>
+      <a href="/history" class="text-xs font-medium text-primary hover:text-accent">View History</a>
+    </div>
+    <div id="up-next-list" class="up-next-list"></div>
+  </section>
+
   <!-- Charts Row -->
   <section class="grid grid-cols-1 gap-6 lg:grid-cols-3" data-dashboard-section>
     <!-- Activity Timeline -->
@@ -253,5 +262,6 @@
 {% block scripts %}
   <script src="{{ static_url('/static/chart.min.js') }}" defer></script>
   <script src="{{ static_url('/static/status-utils.js') }}" defer></script>
+  <script src="{{ static_url('/static/watch-utils.js') }}" defer></script>
   <script src="{{ static_url('/static/page-home.js') }}" defer></script>
 {% endblock %}

--- a/backend/src/librarysync/templates/index.html
+++ b/backend/src/librarysync/templates/index.html
@@ -131,6 +131,10 @@
       <a href="/history" class="text-xs font-medium text-primary hover:text-accent">View History</a>
     </div>
     <div id="up-next-list" class="up-next-list"></div>
+    <div id="up-next-footer" class="up-next-footer" hidden>
+      <span class="up-next-count"></span>
+      <button type="button" class="up-next-toggle" aria-expanded="false">Show more</button>
+    </div>
   </section>
 
   <!-- Charts Row -->

--- a/backend/tests/test_next_episode.py
+++ b/backend/tests/test_next_episode.py
@@ -1,0 +1,88 @@
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+
+from librarysync.api.routes_dashboard import order_up_next_items
+from librarysync.core.next_episode import episode_to_payload, select_next_episode
+
+
+def _episode(episode_id, season, episode_number, air_date=None, title="Episode"):
+    return SimpleNamespace(
+        id=episode_id,
+        show_media_item_id="show-1",
+        season_number=season,
+        episode_number=episode_number,
+        title=title,
+        air_date=air_date,
+    )
+
+
+class TestSelectNextEpisode:
+    def test_returns_first_unwatched_episode(self):
+        episodes = [_episode("e1", 1, 1), _episode("e2", 1, 2), _episode("e3", 1, 3)]
+        assert select_next_episode(episodes, {"e1", "e2"}) is episodes[2]
+
+    def test_returns_first_episode_when_nothing_watched(self):
+        episodes = [_episode("e1", 1, 1), _episode("e2", 1, 2)]
+        assert select_next_episode(episodes, set()) is episodes[0]
+
+    def test_returns_none_when_all_watched(self):
+        episodes = [_episode("e1", 1, 1), _episode("e2", 1, 2)]
+        assert select_next_episode(episodes, {"e1", "e2"}) is None
+
+    def test_returns_none_for_empty_list(self):
+        assert select_next_episode([], set()) is None
+
+
+class TestEpisodeToPayload:
+    def test_serializes_episode_fields(self):
+        episode = _episode("e1", 2, 5, air_date=date(2024, 3, 1), title="Finale")
+        payload = episode_to_payload(episode)
+        assert payload == {
+            "episode_item_id": "e1",
+            "season_number": 2,
+            "episode_number": 5,
+            "title": "Finale",
+            "air_date": "2024-03-01",
+        }
+
+    def test_handles_missing_air_date(self):
+        episode = _episode("e1", 1, 1, air_date=None)
+        assert episode_to_payload(episode)["air_date"] is None
+
+
+class TestOrderUpNextItems:
+    def _item(self, media_item_id, last_watched_at, is_new_release):
+        return {
+            "media_item_id": media_item_id,
+            "last_watched_at": datetime(2024, 1, last_watched_at, tzinfo=timezone.utc),
+            "is_new_release": is_new_release,
+        }
+
+    def test_continue_watching_comes_before_new_releases(self):
+        binge = self._item("binge", 10, False)
+        new_release = self._item("new", 20, True)
+        ordered = order_up_next_items([new_release, binge])
+        assert [item["media_item_id"] for item in ordered] == ["binge", "new"]
+
+    def test_groups_are_ordered_by_last_watched_desc(self):
+        items = [
+            self._item("old-binge", 5, False),
+            self._item("recent-binge", 12, False),
+            self._item("stale-new", 2, True),
+            self._item("fresh-new", 8, True),
+        ]
+        ordered = order_up_next_items(items)
+        assert [item["media_item_id"] for item in ordered] == [
+            "recent-binge",
+            "old-binge",
+            "fresh-new",
+            "stale-new",
+        ]
+
+    def test_new_release_for_recently_watched_show_outranks_old_show(self):
+        # A new episode for a show watched a week ago ranks above a new
+        # episode for a show not watched in two years.
+        week_ago = self._item("week-ago", 11, True)
+        two_years_ago = self._item("two-years-ago", 1, True)
+        ordered = order_up_next_items([two_years_ago, week_ago])
+        assert [item["media_item_id"] for item in ordered] == ["week-ago", "two-years-ago"]

--- a/backend/tests/test_next_episode.py
+++ b/backend/tests/test_next_episode.py
@@ -1,8 +1,19 @@
 from datetime import date, datetime, timezone
 from types import SimpleNamespace
 
+import pytest
+import pytest_asyncio
 from librarysync.api.routes_dashboard import order_up_next_items
-from librarysync.core.next_episode import episode_to_payload, select_next_episode
+from librarysync.core.next_episode import (
+    episode_to_payload,
+    find_next_episode,
+    find_next_episodes_bulk,
+    mark_next_episode_watched,
+    select_next_episode,
+)
+from librarysync.db.models import Base, EpisodeItem, MediaItem, OutboxJob, User, WatchedItem, WatchEvent
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 
 def _episode(episode_id, season, episode_number, air_date=None, title="Episode"):
@@ -86,3 +97,246 @@ class TestOrderUpNextItems:
         two_years_ago = self._item("two-years-ago", 1, True)
         ordered = order_up_next_items([two_years_ago, week_ago])
         assert [item["media_item_id"] for item in ordered] == ["week-ago", "two-years-ago"]
+
+    def test_ordering_does_not_mutate_input(self):
+        first = self._item("first", 1, True)
+        second = self._item("second", 2, False)
+        original = [first, second]
+        ordered = order_up_next_items(original)
+        assert [item["media_item_id"] for item in original] == ["first", "second"]
+        assert [item["media_item_id"] for item in ordered] == ["second", "first"]
+
+
+@pytest_asyncio.fixture
+async def db_session(tmp_path) -> AsyncSession:
+    pytest.importorskip("aiosqlite")
+    db_path = tmp_path / "next-episode-test.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            Base.metadata.create_all,
+            tables=[
+                User.__table__,
+                MediaItem.__table__,
+                EpisodeItem.__table__,
+                WatchedItem.__table__,
+                WatchEvent.__table__,
+                OutboxJob.__table__,
+            ],
+        )
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _create_user(db: AsyncSession, username: str = "tester") -> User:
+    user = User(username=username, password_hash="hash")
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _create_show(
+    db: AsyncSession,
+    title: str,
+    *,
+    media_type: str = "tv",
+) -> MediaItem:
+    show = MediaItem(media_type=media_type, title=title)
+    db.add(show)
+    await db.flush()
+    return show
+
+
+async def _create_episode(
+    db: AsyncSession,
+    show_id: str,
+    season_number: int,
+    episode_number: int,
+    air_date: date,
+    *,
+    title: str,
+) -> EpisodeItem:
+    episode = EpisodeItem(
+        show_media_item_id=show_id,
+        season_number=season_number,
+        episode_number=episode_number,
+        air_date=air_date,
+        title=title,
+    )
+    db.add(episode)
+    await db.flush()
+    return episode
+
+
+@pytest.mark.asyncio
+async def test_find_next_episode_and_bulk_return_first_released_unwatched(db_session: AsyncSession):
+    user = await _create_user(db_session)
+    first_show = await _create_show(db_session, "Show One")
+    second_show = await _create_show(db_session, "Show Two")
+
+    first_show_ep1 = await _create_episode(
+        db_session,
+        first_show.id,
+        1,
+        1,
+        date(2024, 1, 1),
+        title="Show One E1",
+    )
+    first_show_ep2 = await _create_episode(
+        db_session,
+        first_show.id,
+        1,
+        2,
+        date(2024, 1, 2),
+        title="Show One E2",
+    )
+    second_show_ep1 = await _create_episode(
+        db_session,
+        second_show.id,
+        1,
+        1,
+        date(2024, 1, 1),
+        title="Show Two E1",
+    )
+    second_show_ep2 = await _create_episode(
+        db_session,
+        second_show.id,
+        1,
+        2,
+        date(2024, 1, 3),
+        title="Show Two E2",
+    )
+
+    db_session.add_all(
+        [
+            # Episode-level watched rows should be respected.
+            WatchedItem(
+                user_id=user.id,
+                media_item_id=None,
+                episode_item_id=first_show_ep1.id,
+                watched_at=datetime(2024, 1, 4, tzinfo=timezone.utc),
+                source="manual",
+            ),
+            WatchedItem(
+                user_id=user.id,
+                media_item_id=None,
+                episode_item_id=second_show_ep1.id,
+                watched_at=datetime(2024, 1, 4, tzinfo=timezone.utc),
+                source="manual",
+            ),
+            # Media-level watched row should be ignored for next-episode selection.
+            WatchedItem(
+                user_id=user.id,
+                media_item_id=first_show.id,
+                episode_item_id=None,
+                watched_at=datetime(2024, 1, 4, tzinfo=timezone.utc),
+                source="manual",
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    now_date = date(2024, 1, 10)
+    next_first_show = await find_next_episode(db_session, user.id, first_show.id, now_date)
+    assert next_first_show is not None
+    assert next_first_show.id == first_show_ep2.id
+
+    bulk_next = await find_next_episodes_bulk(
+        db_session,
+        user.id,
+        [first_show.id, second_show.id],
+        now_date,
+    )
+    assert bulk_next[first_show.id].id == first_show_ep2.id
+    assert bulk_next[second_show.id].id == second_show_ep2.id
+
+
+@pytest.mark.asyncio
+async def test_mark_next_episode_watched_creates_watched_event_and_internal_outbox_job(
+    db_session: AsyncSession,
+):
+    user = await _create_user(db_session)
+    show = await _create_show(db_session, "Up Next Show")
+    first_episode = await _create_episode(
+        db_session,
+        show.id,
+        1,
+        1,
+        date(2024, 1, 1),
+        title="Pilot",
+    )
+    await _create_episode(
+        db_session,
+        show.id,
+        1,
+        2,
+        date(2024, 1, 2),
+        title="Episode 2",
+    )
+
+    watched, marked_episode = await mark_next_episode_watched(db_session, user.id, show)
+
+    assert marked_episode.id == first_episode.id
+
+    watched_row = await db_session.get(WatchedItem, watched.id)
+    assert watched_row is not None
+    assert watched_row.episode_item_id == first_episode.id
+    assert watched_row.media_item_id is None
+
+    events = (
+        await db_session.execute(
+            select(WatchEvent).where(
+                WatchEvent.user_id == user.id,
+                WatchEvent.episode_item_id == first_episode.id,
+                WatchEvent.event_type == "manual_watched",
+            )
+        )
+    ).scalars().all()
+    assert len(events) == 1
+
+    outbox_jobs = (
+        await db_session.execute(
+            select(OutboxJob).where(
+                OutboxJob.user_id == user.id,
+                OutboxJob.target_provider == "internal",
+                OutboxJob.job_type == "new_item_added",
+            )
+        )
+    ).scalars().all()
+    assert len(outbox_jobs) == 1
+    assert outbox_jobs[0].payload.get("watched_item_id") == watched.id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("setup", ["all_watched", "no_released"])
+async def test_mark_next_episode_watched_raises_value_error_when_no_next_episode(
+    db_session: AsyncSession,
+    setup: str,
+):
+    user = await _create_user(db_session)
+    show = await _create_show(db_session, "No Next Show")
+
+    episode = await _create_episode(
+        db_session,
+        show.id,
+        1,
+        1,
+        date(2024, 1, 1) if setup == "all_watched" else date(2100, 1, 1),
+        title="Episode",
+    )
+    if setup == "all_watched":
+        db_session.add(
+            WatchedItem(
+                user_id=user.id,
+                media_item_id=None,
+                episode_item_id=episode.id,
+                watched_at=datetime(2024, 1, 2, tzinfo=timezone.utc),
+                source="manual",
+            )
+        )
+        await db_session.flush()
+
+    with pytest.raises(ValueError, match="No released, unwatched episode found for this show"):
+        await mark_next_episode_watched(db_session, user.id, show)

--- a/frontend/input.css
+++ b/frontend/input.css
@@ -497,11 +497,58 @@
   }
 
   .up-next-list {
-    @apply grid gap-4 p-4 sm:grid-cols-2;
+    @apply divide-y divide-line/40 px-2 py-1;
   }
 
+  .up-next-row {
+    @apply flex items-center gap-3 px-3 py-2.5 transition-colors hover:bg-elevated/40 rounded-xl;
+  }
+
+  .up-next-thumb {
+    @apply h-[52px] w-[36px] flex-none rounded-md bg-elevated object-cover shadow-sm;
+  }
+
+  .up-next-body {
+    @apply min-w-0 flex-1;
+  }
+
+  .up-next-title-row {
+    @apply flex items-center gap-2 min-w-0;
+  }
+
+  .up-next-title {
+    @apply truncate text-sm font-semibold text-ink leading-5;
+  }
+
+  .up-next-episode {
+    @apply flex-none text-xs font-medium text-primary;
+  }
+
+  .up-next-meta {
+    @apply truncate text-xs text-muted leading-4 mt-0.5;
+  }
+
+  .up-next-action {
+    @apply flex-none;
+  }
+
+  .up-next-new-badge {
+    flex-shrink: 0;
+    border-radius: 999px;
+    background-color: color-mix(in srgb, var(--color-primary) 15%, transparent);
+    color: var(--color-primary);
+    border: 1px solid color-mix(in srgb, var(--color-primary) 25%, transparent);
+    padding: 0.1rem 0.45rem;
+    font-size: 0.6rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  /* Keep old up-next-card for fallback, replaced by up-next-row */
   .up-next-card {
-    @apply grid grid-cols-[64px,1fr] items-center gap-4 rounded-xl border border-line/70 bg-surface/70 p-4;
+    @apply flex items-center gap-3 px-3 py-2.5 transition-colors hover:bg-elevated/40 rounded-xl;
   }
 
   .history-card.is-watched {

--- a/frontend/input.css
+++ b/frontend/input.css
@@ -546,6 +546,18 @@
     white-space: nowrap;
   }
 
+  .up-next-footer {
+    @apply flex items-center justify-between border-t border-line/40 px-5 py-2.5;
+  }
+
+  .up-next-count {
+    @apply text-xs text-muted;
+  }
+
+  .up-next-toggle {
+    @apply text-xs font-medium text-primary transition-colors hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 rounded;
+  }
+
   /* Keep old up-next-card for fallback, replaced by up-next-row */
   .up-next-card {
     @apply flex items-center gap-3 px-3 py-2.5 transition-colors hover:bg-elevated/40 rounded-xl;

--- a/frontend/input.css
+++ b/frontend/input.css
@@ -496,6 +496,14 @@
     @apply grid grid-cols-[auto,64px,1fr] items-start gap-4 rounded-xl border border-line/70 bg-surface/70 p-4;
   }
 
+  .up-next-list {
+    @apply grid gap-4 p-4 sm:grid-cols-2;
+  }
+
+  .up-next-card {
+    @apply grid grid-cols-[64px,1fr] items-center gap-4 rounded-xl border border-line/70 bg-surface/70 p-4;
+  }
+
   .history-card.is-watched {
     @apply border-line/50 bg-elevated/60;
     position: relative;

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,15 @@ members = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.18.5"
 source = { registry = "https://pypi.org/simple" }
@@ -486,6 +495,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aiosqlite" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -510,6 +520,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "ruff", specifier = ">=0.15.3" },


### PR DESCRIPTION
## Summary

- **History**: show rows now expose the next released, unwatched episode (`next_episode` on `GET /api/history/items`) and the item menu gets a "Mark SxxEyy watched" action — only when the episode is already released. Backed by `POST /api/history/shows/{media_item_id}/mark-next-episode`.
- **Dashboard**: new "Up Next" section listing shows with a released, unwatched next episode, with one-click marking. Ordering: continue-watching shows first (next episode was already out at last watch — the binge case), then newly released episodes, each group ordered by most recently watched. A "New episode" badge marks fresh releases.
- **Shared logic**: new `core/next_episode.py` (find next unwatched released episode, single + bulk; mark as watched incl. audit event and outbox sync jobs). The watchlist mark-watched route now reuses it.
- Adds `GET /api/dashboard/up-next`.

## Test plan

- [x] `backend/tests/test_next_episode.py` — selection logic, payload serialization, up-next group ordering (9 tests); full suite: 258 passed
- [x] Ruff clean
- [x] Live Postgres checks of all helper logic (rolled back)
- [x] HTTP + browser E2E: dashboard card renders and marks correctly, section hides when caught up, history menu gates the action on released episodes