### PR TITLE
Add dropped watchlist status for TV and anime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,7 @@ Handles job types: `push_watched`, `push_rating`, `update_history`, `remove_hist
 #### Import Jobs
 - **`quick_import`**: Runs 7-day import window on the user's configured schedule (30 min to 7 days). Per-user runs are single-flight via a lease stored in the integration config (10-minute expiry, refreshed at each claim); an expired lease lets any worker resume a stuck run from its saved queue index
 - **`import_all`**: Sequences providers per user for full import
+- **Dropped ingestion**: Trakt (`GET /users/hidden/dropped?type=show`) and SIMKL (`status: "dropped"` in `/sync/all-items`) dropped shows are imported into the terminal `dropped` watchlist status, tracked via a per-provider `WatchlistSource` (`external_id="dropped"`); reconcile un-drops shows that leave the provider's dropped list. Import upserts never resurrect dropped items (`restore_dropped=False`)
 - **`merge_history`**: Post-import deduplication (same-day movie entries) and repoints sync/outbox rows
 - **`merge_all_history`**: Periodic deduplication of all user history in database (API merges on-the-fly until DB is clean)
 

--- a/backend/src/librarysync/api/routes_admin.py
+++ b/backend/src/librarysync/api/routes_admin.py
@@ -20,7 +20,7 @@ from librarysync.core.watch_pipeline import (
     build_stremio_payload,
     build_trakt_payload,
 )
-from librarysync.core.watchlist import normalize_media_ids
+from librarysync.core.watchlist import WATCHLIST_TERMINAL_STATUSES, normalize_media_ids
 from librarysync.core.watchlist_sync import enqueue_personal_watchlist_sync
 from librarysync.db.models import (
     EpisodeItem,
@@ -529,7 +529,7 @@ async def _enqueue_personal_watchlist_resync(
     result = await db.execute(
         select(WatchlistItem).where(
             WatchlistItem.media_item_id == media_item.id,
-            WatchlistItem.status.notin_(["removed", "dropped"]),
+            WatchlistItem.status.notin_(WATCHLIST_TERMINAL_STATUSES),
         )
     )
     for watchlist_item in result.scalars().all():

--- a/backend/src/librarysync/api/routes_admin.py
+++ b/backend/src/librarysync/api/routes_admin.py
@@ -74,6 +74,7 @@ MEDIA_EXTERNAL_ID_FIELDS_WITH_TYPE = {
 }
 WATCHLIST_STATUS_RANK = {
     "removed": 0,
+    "dropped": 1,
     "hidden": 1,
     "added": 2,
     "not_released": 2,
@@ -528,7 +529,7 @@ async def _enqueue_personal_watchlist_resync(
     result = await db.execute(
         select(WatchlistItem).where(
             WatchlistItem.media_item_id == media_item.id,
-            WatchlistItem.status != "removed",
+            WatchlistItem.status.notin_(["removed", "dropped"]),
         )
     )
     for watchlist_item in result.scalars().all():

--- a/backend/src/librarysync/api/routes_metadata.py
+++ b/backend/src/librarysync/api/routes_metadata.py
@@ -971,7 +971,7 @@ async def lookup_local(
         .where(
             WatchlistItem.user_id == current_user.id,
             WatchlistItem.media_item_id.is_not(None),
-            WatchlistItem.status != "removed",
+            WatchlistItem.status.notin_(["removed", "dropped"]),
         )
         .group_by(WatchlistItem.media_item_id)
         .subquery()

--- a/backend/src/librarysync/api/routes_metadata.py
+++ b/backend/src/librarysync/api/routes_metadata.py
@@ -32,6 +32,7 @@ from librarysync.core.metadata_providers import (
     TvdbProviderSettings,
     TvmazeProviderSettings,
 )
+from librarysync.core.watchlist import WATCHLIST_TERMINAL_STATUSES
 from librarysync.db.models import (
     EpisodeItem,
     MediaItem,
@@ -971,7 +972,7 @@ async def lookup_local(
         .where(
             WatchlistItem.user_id == current_user.id,
             WatchlistItem.media_item_id.is_not(None),
-            WatchlistItem.status.notin_(["removed", "dropped"]),
+            WatchlistItem.status.notin_(WATCHLIST_TERMINAL_STATUSES),
         )
         .group_by(WatchlistItem.media_item_id)
         .subquery()

--- a/backend/src/librarysync/api/routes_stremio_addon_public.py
+++ b/backend/src/librarysync/api/routes_stremio_addon_public.py
@@ -20,7 +20,11 @@ from librarysync.core.stremio_addon import (
     get_addon_config_by_id,
     normalize_default_catalogs,
 )
-from librarysync.core.watchlist import apply_show_status_filter, normalize_watchlist_statuses
+from librarysync.core.watchlist import (
+    WATCHLIST_TERMINAL_STATUSES,
+    apply_show_status_filter,
+    normalize_watchlist_statuses,
+)
 from librarysync.db.models import (
     MediaItem,
     StremioCustomCatalog,
@@ -296,7 +300,7 @@ async def _build_watchlist_query(
         .join(WatchlistItem, WatchlistItem.media_item_id == MediaItem.id)
         .where(
             WatchlistItem.user_id == user_id,
-            WatchlistItem.status.notin_(["removed", "dropped"]),
+            WatchlistItem.status.notin_(WATCHLIST_TERMINAL_STATUSES),
         )
     )
     media_type = catalog.get("media_type")
@@ -346,7 +350,7 @@ async def _build_in_progress_query(
         .outerjoin(progress_subq, progress_subq.c.media_item_id == MediaItem.id)
         .where(
             WatchlistItem.user_id == user_id,
-            WatchlistItem.status.notin_(["removed", "dropped"]),
+            WatchlistItem.status.notin_(WATCHLIST_TERMINAL_STATUSES),
             WatchlistItem.type.in_(["tv", "anime"]),
             MediaItem.media_type.in_(["tv", "anime"]),
         )

--- a/backend/src/librarysync/api/routes_stremio_addon_public.py
+++ b/backend/src/librarysync/api/routes_stremio_addon_public.py
@@ -296,7 +296,7 @@ async def _build_watchlist_query(
         .join(WatchlistItem, WatchlistItem.media_item_id == MediaItem.id)
         .where(
             WatchlistItem.user_id == user_id,
-            WatchlistItem.status != "removed",
+            WatchlistItem.status.notin_(["removed", "dropped"]),
         )
     )
     media_type = catalog.get("media_type")
@@ -346,7 +346,7 @@ async def _build_in_progress_query(
         .outerjoin(progress_subq, progress_subq.c.media_item_id == MediaItem.id)
         .where(
             WatchlistItem.user_id == user_id,
-            WatchlistItem.status != "removed",
+            WatchlistItem.status.notin_(["removed", "dropped"]),
             WatchlistItem.type.in_(["tv", "anime"]),
             MediaItem.media_type.in_(["tv", "anime"]),
         )

--- a/backend/src/librarysync/api/routes_watchlist.py
+++ b/backend/src/librarysync/api/routes_watchlist.py
@@ -542,7 +542,11 @@ async def list_watchlist_items(
         .join(MediaItem, WatchlistItem.media_item_id == MediaItem.id)
         .where(WatchlistItem.user_id == current_user.id)
     )
-    if not status or status == "all":
+    # Dropped items stay hidden unless explicitly requested via the status
+    # filter. The UI's "all" view sends an expanded status list, so this must
+    # not rely on the literal "all" value; the computed show-status filter
+    # would otherwise match dropped rows via their watch progress.
+    if "dropped" not in status_filter_values:
         query = query.where(WatchlistItem.status != "dropped")
 
     if status and status != "all" and status_filter_values:
@@ -854,7 +858,7 @@ async def restore_watchlist_item(
     )
     if media_item.media_type in {"tv", "anime"}:
         await evaluate_show_watchlist_status(db, current_user.id, item, media_item)
-    await enqueue_personal_watchlist_sync(db, item, media_item)
+    await enqueue_personal_watchlist_sync(db, item, media_item, unhide_dropped=True)
     await db.commit()
     return {"id": item.id, "status": "updated"}
 

--- a/backend/src/librarysync/api/routes_watchlist.py
+++ b/backend/src/librarysync/api/routes_watchlist.py
@@ -26,6 +26,7 @@ from librarysync.core.watchlist import (
     clear_watchlist_rewatch_request,
     determine_movie_watchlist_status,
     determine_show_watchlist_status,
+    evaluate_show_watchlist_status,
     log_watchlist_event,
     normalize_media_ids,
     normalize_watchlist_statuses,
@@ -782,6 +783,11 @@ async def drop_watchlist_item(
         )
 
     item, media_item = row
+    if media_item.media_type not in {"tv", "anime"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Drop is only supported for TV/anime watchlist items",
+        )
     if item.status == "dropped":
         return {"id": item.id, "status": "unchanged"}
 
@@ -846,6 +852,8 @@ async def restore_watchlist_item(
         "watchlist_status_changed",
         {"status": "added", "previous_status": "dropped", "reason": "manual"},
     )
+    if media_item.media_type in {"tv", "anime"}:
+        await evaluate_show_watchlist_status(db, current_user.id, item, media_item)
     await enqueue_personal_watchlist_sync(db, item, media_item)
     await db.commit()
     return {"id": item.id, "status": "updated"}

--- a/backend/src/librarysync/api/routes_watchlist.py
+++ b/backend/src/librarysync/api/routes_watchlist.py
@@ -27,7 +27,9 @@ from librarysync.core.watchlist import (
     determine_movie_watchlist_status,
     determine_show_watchlist_status,
     evaluate_show_watchlist_status,
+    find_media_item_by_ids,
     log_watchlist_event,
+    mark_watchlist_item_dropped,
     normalize_media_ids,
     normalize_watchlist_statuses,
     set_watchlist_rewatch_request,
@@ -176,6 +178,20 @@ async def add_watchlist_item(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Provide at least one external ID",
         )
+    # Remember whether this is a dropped item being re-added so the provider
+    # sync below un-hides it from the provider's dropped section; otherwise the
+    # next dropped import would flip it straight back to dropped.
+    was_dropped = False
+    existing_media_item = await find_media_item_by_ids(db, payload.media_type, media_ids)
+    if existing_media_item:
+        existing_result = await db.execute(
+            select(WatchlistItem).where(
+                WatchlistItem.user_id == current_user.id,
+                WatchlistItem.media_item_id == existing_media_item.id,
+                WatchlistItem.status == "dropped",
+            )
+        )
+        was_dropped = existing_result.scalars().first() is not None
     watchlist_item, status_value = await upsert_watchlist_item(
         db,
         current_user.id,
@@ -214,7 +230,7 @@ async def add_watchlist_item(
             select(MediaItem).where(MediaItem.id == watchlist_item.media_item_id)
         )
         media_item = media_result.scalars().first()
-        await enqueue_personal_watchlist_sync(db, watchlist_item, media_item)
+        await enqueue_personal_watchlist_sync(db, watchlist_item, media_item, unhide_dropped=was_dropped)
         await db.commit()
     return {"id": watchlist_item.id, "status": status_value}
 
@@ -795,24 +811,12 @@ async def drop_watchlist_item(
     if item.status == "dropped":
         return {"id": item.id, "status": "unchanged"}
 
-    previous_status = item.status
-    effective_now = datetime.now(timezone.utc)
-    await clear_watchlist_rewatch_request(
+    await mark_watchlist_item_dropped(
         db,
         item,
         current_user.id,
         item.media_item_id,
-        reason="dropped",
-        now=effective_now,
-    )
-    item.status = "dropped"
-    item.updated_at = effective_now
-    await log_watchlist_event(
-        db,
-        current_user.id,
-        item.media_item_id,
-        "watchlist_status_changed",
-        {"status": "dropped", "previous_status": previous_status, "reason": "manual"},
+        reason="manual",
     )
     await enqueue_personal_watchlist_removal(db, item, media_item)
     await db.commit()

--- a/backend/src/librarysync/api/routes_watchlist.py
+++ b/backend/src/librarysync/api/routes_watchlist.py
@@ -20,6 +20,7 @@ from librarysync.core.next_episode import SHOW_MEDIA_TYPES, find_next_episode, h
 from librarysync.core.publicmetadb import is_publicmetadb_sync_enabled
 from librarysync.core.watch_pipeline import enqueue_new_item_job
 from librarysync.core.watchlist import (
+    WATCHLIST_TERMINAL_STATUSES,
     apply_combined_status_filter,
     apply_watchlist_status_change,
     clear_watchlist_rewatch_request,
@@ -540,6 +541,8 @@ async def list_watchlist_items(
         .join(MediaItem, WatchlistItem.media_item_id == MediaItem.id)
         .where(WatchlistItem.user_id == current_user.id)
     )
+    if not status or status == "all":
+        query = query.where(WatchlistItem.status != "dropped")
 
     if status and status != "all" and status_filter_values:
         filter_now_date = datetime.now(timezone.utc).date()
@@ -666,7 +669,7 @@ async def list_watchlist_items(
                 now_date=now_date,
             )
 
-        if item.status != "removed" and item.status != desired_status:
+        if item.status not in WATCHLIST_TERMINAL_STATUSES and item.status != desired_status:
             if await apply_watchlist_status_change(
                 db,
                 item,
@@ -755,6 +758,100 @@ async def remove_watchlist_item(
 
 
 @router.post(
+    "/items/{watchlist_id}/drop",
+    summary="Drop watchlist item",
+    description="Mark a watchlist item as dropped and sync removal to providers.",
+)
+async def drop_watchlist_item(
+    watchlist_id: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    result = await db.execute(
+        select(WatchlistItem, MediaItem)
+        .join(MediaItem, WatchlistItem.media_item_id == MediaItem.id)
+        .where(
+            WatchlistItem.id == watchlist_id,
+            WatchlistItem.user_id == current_user.id,
+        )
+    )
+    row = result.first()
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Watchlist item not found"
+        )
+
+    item, media_item = row
+    if item.status == "dropped":
+        return {"id": item.id, "status": "unchanged"}
+
+    previous_status = item.status
+    effective_now = datetime.now(timezone.utc)
+    await clear_watchlist_rewatch_request(
+        db,
+        item,
+        current_user.id,
+        item.media_item_id,
+        reason="dropped",
+        now=effective_now,
+    )
+    item.status = "dropped"
+    item.updated_at = effective_now
+    await log_watchlist_event(
+        db,
+        current_user.id,
+        item.media_item_id,
+        "watchlist_status_changed",
+        {"status": "dropped", "previous_status": previous_status, "reason": "manual"},
+    )
+    await enqueue_personal_watchlist_removal(db, item, media_item)
+    await db.commit()
+    return {"id": item.id, "status": "updated"}
+
+
+@router.delete(
+    "/items/{watchlist_id}/drop",
+    summary="Restore dropped watchlist item",
+    description="Restore a dropped watchlist item to added and sync it to providers.",
+)
+async def restore_watchlist_item(
+    watchlist_id: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    result = await db.execute(
+        select(WatchlistItem, MediaItem)
+        .join(MediaItem, WatchlistItem.media_item_id == MediaItem.id)
+        .where(
+            WatchlistItem.id == watchlist_id,
+            WatchlistItem.user_id == current_user.id,
+        )
+    )
+    row = result.first()
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Watchlist item not found"
+        )
+
+    item, media_item = row
+    if item.status != "dropped":
+        return {"id": item.id, "status": "unchanged"}
+
+    item.status = "added"
+    item.updated_at = datetime.now(timezone.utc)
+    await log_watchlist_event(
+        db,
+        current_user.id,
+        item.media_item_id,
+        "watchlist_status_changed",
+        {"status": "added", "previous_status": "dropped", "reason": "manual"},
+    )
+    await enqueue_personal_watchlist_sync(db, item, media_item)
+    await db.commit()
+    return {"id": item.id, "status": "updated"}
+
+
+@router.post(
     "/items/{watchlist_id}/rewatch",
     summary="Enable watchlist rewatch",
     description="Force a watched item to stay in the watchlist until it is watched again.",
@@ -778,10 +875,10 @@ async def enable_watchlist_rewatch(
             status_code=status.HTTP_404_NOT_FOUND, detail="Watchlist item not found"
         )
     item, media_item = row
-    if item.status == "removed":
+    if item.status in WATCHLIST_TERMINAL_STATUSES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Removed watchlist items cannot be queued for rewatch",
+            detail="Removed or dropped watchlist items cannot be queued for rewatch",
         )
 
     if media_item.media_type == "movie":
@@ -1101,7 +1198,7 @@ async def _refresh_watchlist_statuses_for_filter(
     progress_map = await _get_show_progress_bulk(db, user_id, tv_media_ids)
     status_changed = False
     for item, media in rows:
-        if item.status == "removed":
+        if item.status in WATCHLIST_TERMINAL_STATUSES:
             continue
         desired_status = item.status
         if media.media_type == "tv":

--- a/backend/src/librarysync/connectors/services/simkl.py
+++ b/backend/src/librarysync/connectors/services/simkl.py
@@ -228,6 +228,15 @@ class SimklClient:
         parsed = self._parse_json(response)
         return parsed if isinstance(parsed, dict) else {}, response.status_code
 
+    async def add_to_list(
+        self, payload: dict[str, Any], access_token: str
+    ) -> tuple[dict[str, Any], int]:
+        response = await self._request(
+            "POST", "/sync/add-to-list", access_token=access_token, json_body=payload
+        )
+        parsed = self._parse_json(response)
+        return parsed if isinstance(parsed, dict) else {}, response.status_code
+
     async def fetch_history(
         self,
         access_token: str,

--- a/backend/src/librarysync/connectors/services/simkl.py
+++ b/backend/src/librarysync/connectors/services/simkl.py
@@ -214,7 +214,7 @@ class SimklClient:
         self, payload: dict[str, Any], access_token: str
     ) -> tuple[dict[str, Any], int]:
         response = await self._request(
-            "POST", "/sync/watchlist", access_token=access_token, json_body=payload
+            "POST", "/sync/add-to-list", access_token=access_token, json_body=payload
         )
         parsed = self._parse_json(response)
         return parsed if isinstance(parsed, dict) else {}, response.status_code
@@ -223,7 +223,7 @@ class SimklClient:
         self, payload: dict[str, Any], access_token: str
     ) -> tuple[dict[str, Any], int]:
         response = await self._request(
-            "POST", "/sync/watchlist/remove", access_token=access_token, json_body=payload
+            "POST", "/sync/history/remove", access_token=access_token, json_body=payload
         )
         parsed = self._parse_json(response)
         return parsed if isinstance(parsed, dict) else {}, response.status_code

--- a/backend/src/librarysync/connectors/services/trakt.py
+++ b/backend/src/librarysync/connectors/services/trakt.py
@@ -359,6 +359,52 @@ class TraktClient:
             page += 1
         return entries
 
+    async def fetch_hidden_items(
+        self,
+        access_token: str,
+        section: str,
+        item_type: str | None = None,
+        page: int = 1,
+        limit: int = 50,
+    ) -> tuple[list[dict[str, Any]], dict[str, str]]:
+        path = f"/users/hidden/{section}"
+        params: dict[str, str] = {"page": str(page), "limit": str(limit)}
+        if item_type:
+            params["type"] = item_type
+        response = await self._request("GET", path, access_token=access_token, params=params)
+        payload = self._parse_json(response)
+        items = _coerce_items(payload)
+        return items, dict(response.headers)
+
+    async def get_hidden_items(
+        self,
+        access_token: str,
+        section: str,
+        item_type: str | None = None,
+        per_page: int = 50,
+        max_pages: int | None = 10,
+    ) -> list[dict[str, Any]]:
+        entries: list[dict[str, Any]] = []
+        page = 1
+        while max_pages is None or page <= max_pages:
+            items, headers = await self.fetch_hidden_items(
+                access_token,
+                section=section,
+                item_type=item_type,
+                page=page,
+                limit=per_page,
+            )
+            if not items:
+                break
+            entries.extend(item for item in items if isinstance(item, dict))
+            page_count = _parse_page_count(headers)
+            if page_count and page >= page_count:
+                break
+            if len(items) < per_page:
+                break
+            page += 1
+        return entries
+
     async def add_to_watchlist(
         self, payload: dict[str, Any], access_token: str
     ) -> tuple[dict[str, Any], int]:

--- a/backend/src/librarysync/connectors/services/trakt.py
+++ b/backend/src/librarysync/connectors/services/trakt.py
@@ -374,12 +374,13 @@ class TraktClient:
         self, payload: dict[str, Any], access_token: str
     ) -> tuple[dict[str, Any], int]:
         response = await self._request(
-            "POST",
-            "/sync/watchlist/remove",
+            "DELETE",
+            "/sync/watchlist",
             access_token=access_token,
             json_body=payload,
         )
-        return self._parse_json(response), response.status_code
+        parsed = self._parse_json(response)
+        return parsed if isinstance(parsed, dict) else {}, response.status_code
 
     async def fetch_trending_lists(
         self,

--- a/backend/src/librarysync/connectors/services/trakt.py
+++ b/backend/src/librarysync/connectors/services/trakt.py
@@ -374,8 +374,32 @@ class TraktClient:
         self, payload: dict[str, Any], access_token: str
     ) -> tuple[dict[str, Any], int]:
         response = await self._request(
-            "DELETE",
-            "/sync/watchlist",
+            "POST",
+            "/sync/watchlist/remove",
+            access_token=access_token,
+            json_body=payload,
+        )
+        parsed = self._parse_json(response)
+        return parsed if isinstance(parsed, dict) else {}, response.status_code
+
+    async def add_hidden_items(
+        self, section: str, payload: dict[str, Any], access_token: str
+    ) -> tuple[dict[str, Any], int]:
+        response = await self._request(
+            "POST",
+            f"/users/hidden/{section}",
+            access_token=access_token,
+            json_body=payload,
+        )
+        parsed = self._parse_json(response)
+        return parsed if isinstance(parsed, dict) else {}, response.status_code
+
+    async def remove_hidden_items(
+        self, section: str, payload: dict[str, Any], access_token: str
+    ) -> tuple[dict[str, Any], int]:
+        response = await self._request(
+            "POST",
+            f"/users/hidden/{section}/remove",
             access_token=access_token,
             json_body=payload,
         )

--- a/backend/src/librarysync/core/watchlist.py
+++ b/backend/src/librarysync/core/watchlist.py
@@ -27,7 +27,8 @@ LEGACY_WATCHLIST_STATUS_MAP = {
     "waiting": "watched",
 }
 SHOW_STATUS_VALUES = {"added", "in_progress", "watched", "not_released"}
-WATCHLIST_TERMINAL_STATUSES = {"removed", "dropped"}
+# Ordered tuple (not a set) so compiled-SQL bind order is deterministic for tests.
+WATCHLIST_TERMINAL_STATUSES = ("removed", "dropped")
 
 
 def _is_future_date(value: date | None, now_date: date) -> bool:
@@ -781,6 +782,36 @@ async def apply_watchlist_status_change(
     return True
 
 
+async def mark_watchlist_item_dropped(
+    db: AsyncSession,
+    watchlist_item: WatchlistItem,
+    user_id: str,
+    media_item_id: str,
+    *,
+    reason: str,
+    now: datetime | None = None,
+) -> None:
+    previous_status = watchlist_item.status
+    effective_now = now or datetime.now(timezone.utc)
+    await clear_watchlist_rewatch_request(
+        db,
+        watchlist_item,
+        user_id,
+        media_item_id,
+        reason="dropped",
+        now=effective_now,
+    )
+    watchlist_item.status = "dropped"
+    watchlist_item.updated_at = effective_now
+    await log_watchlist_event(
+        db,
+        user_id,
+        media_item_id,
+        "watchlist_status_changed",
+        {"status": "dropped", "previous_status": previous_status, "reason": reason},
+    )
+
+
 async def set_watchlist_rewatch_request(
     db: AsyncSession,
     watchlist_item: WatchlistItem,
@@ -1133,6 +1164,7 @@ async def upsert_watchlist_item(
             now=now,
             event_raw=event_raw,
             enqueue_sync=False,
+            restore_dropped=restore_dropped,
         )
     if media_type in {"tv", "anime"}:
         await evaluate_show_watchlist_status(db, user_id, watchlist_item, media_item)

--- a/backend/src/librarysync/core/watchlist.py
+++ b/backend/src/librarysync/core/watchlist.py
@@ -27,6 +27,7 @@ LEGACY_WATCHLIST_STATUS_MAP = {
     "waiting": "watched",
 }
 SHOW_STATUS_VALUES = {"added", "in_progress", "watched", "not_released"}
+WATCHLIST_TERMINAL_STATUSES = {"removed", "dropped"}
 
 
 def _is_future_date(value: date | None, now_date: date) -> bool:
@@ -507,6 +508,19 @@ async def check_and_update_watchlist(
         watched_at=watched_at,
     )
 
+    restored_from_dropped = False
+    if media_item.media_type in {"tv", "anime"} and item.status == "dropped":
+        item.status = "added"
+        item.updated_at = watched_at or datetime.now(timezone.utc)
+        await log_watchlist_event(
+            db,
+            user_id,
+            media_item_id,
+            "watchlist_status_changed",
+            {"status": "added", "previous_status": "dropped", "reason": "watched"},
+        )
+        restored_from_dropped = True
+
     if media_item.media_type == "movie":
         await apply_watchlist_status_change(
             db,
@@ -519,6 +533,8 @@ async def check_and_update_watchlist(
 
     elif media_item.media_type in {"tv", "anime"}:
         await evaluate_show_watchlist_status(db, user_id, item, media_item)
+        if restored_from_dropped:
+            await _enqueue_watchlist_sync(db, item, media_item)
 
 
 async def ensure_show_watchlist_item(
@@ -670,7 +686,7 @@ async def evaluate_show_watchlist_status(
     # 3. If there is at least one released episode that is NOT watched -> Active
     # 4. If all released episodes are watched -> Waiting (if returning) or Watched (if ended)
 
-    if watchlist_item.status == "removed":
+    if watchlist_item.status in WATCHLIST_TERMINAL_STATUSES:
         return
 
     # Find released episodes
@@ -736,7 +752,7 @@ async def apply_watchlist_status_change(
     reason: str,
     now: datetime | None = None,
 ) -> bool:
-    if watchlist_item.status == "removed":
+    if watchlist_item.status in WATCHLIST_TERMINAL_STATUSES:
         return False
     if watchlist_item.status == new_status:
         return False
@@ -771,7 +787,7 @@ async def set_watchlist_rewatch_request(
     reason: str,
     now: datetime | None = None,
 ) -> bool:
-    if watchlist_item.status == "removed":
+    if watchlist_item.status in WATCHLIST_TERMINAL_STATUSES:
         return False
     if watchlist_item.rewatch_requested == enabled:
         return False
@@ -911,27 +927,29 @@ async def _resolve_existing_watchlist_item(
     event_raw: dict[str, Any] | None,
     enqueue_sync: bool = False,
 ) -> tuple[WatchlistItem, str]:
-    if existing.status == "removed":
+    if existing.status in WATCHLIST_TERMINAL_STATUSES:
+        was_dropped = existing.status == "dropped"
         initial_status = "added"
-        now_date = now.date()
-        if media_type == "movie":
-            w_result = await db.execute(
-                select(WatchedItem)
-                .where(
-                    WatchedItem.user_id == user_id,
-                    WatchedItem.media_item_id == media_item.id,
+        if existing.status == "removed":
+            now_date = now.date()
+            if media_type == "movie":
+                w_result = await db.execute(
+                    select(WatchedItem)
+                    .where(
+                        WatchedItem.user_id == user_id,
+                        WatchedItem.media_item_id == media_item.id,
+                    )
+                    .limit(1)
                 )
-                .limit(1)
-            )
-            has_watched = bool(w_result.scalars().first())
-            initial_status = determine_movie_watchlist_status(
-                media_item,
-                has_watched=has_watched,
-                now_date=now_date,
-            )
-        elif media_type in {"tv", "anime"}:
-            if _is_future_date(media_item.first_air_date, now_date):
-                initial_status = "not_released"
+                has_watched = bool(w_result.scalars().first())
+                initial_status = determine_movie_watchlist_status(
+                    media_item,
+                    has_watched=has_watched,
+                    now_date=now_date,
+                )
+            elif media_type in {"tv", "anime"}:
+                if _is_future_date(media_item.first_air_date, now_date):
+                    initial_status = "not_released"
         existing.status = initial_status
         existing.updated_at = now
         if existing.source != source and existing.source != "manual":
@@ -943,7 +961,7 @@ async def _resolve_existing_watchlist_item(
             "watchlist_added",
             {"restored": True, "source": source, **(event_raw or {})},
         )
-        if media_type in {"tv", "anime"}:
+        if media_type in {"tv", "anime"} and not was_dropped:
             await evaluate_show_watchlist_status(db, user_id, existing, media_item)
         if enqueue_sync:
             await _enqueue_watchlist_sync(db, existing, media_item)

--- a/backend/src/librarysync/core/watchlist.py
+++ b/backend/src/librarysync/core/watchlist.py
@@ -470,11 +470,15 @@ async def _enqueue_watchlist_sync(
     db: AsyncSession,
     watchlist_item: WatchlistItem,
     media_item: MediaItem | None,
+    *,
+    unhide_dropped: bool = False,
 ) -> None:
     # Deferred import: watchlist_sync depends on watch_pipeline, which imports this module.
     from librarysync.core.watchlist_sync import enqueue_personal_watchlist_sync
 
-    await enqueue_personal_watchlist_sync(db, watchlist_item, media_item)
+    await enqueue_personal_watchlist_sync(
+        db, watchlist_item, media_item, unhide_dropped=unhide_dropped
+    )
 
 
 async def check_and_update_watchlist(
@@ -534,7 +538,7 @@ async def check_and_update_watchlist(
     elif media_item.media_type in {"tv", "anime"}:
         await evaluate_show_watchlist_status(db, user_id, item, media_item)
         if restored_from_dropped:
-            await _enqueue_watchlist_sync(db, item, media_item)
+            await _enqueue_watchlist_sync(db, item, media_item, unhide_dropped=True)
 
 
 async def ensure_show_watchlist_item(
@@ -964,7 +968,7 @@ async def _resolve_existing_watchlist_item(
         if media_type in {"tv", "anime"} and not was_dropped:
             await evaluate_show_watchlist_status(db, user_id, existing, media_item)
         if enqueue_sync:
-            await _enqueue_watchlist_sync(db, existing, media_item)
+            await _enqueue_watchlist_sync(db, existing, media_item, unhide_dropped=was_dropped)
         return existing, "restored"
     return existing, "already_exists"
 

--- a/backend/src/librarysync/core/watchlist.py
+++ b/backend/src/librarysync/core/watchlist.py
@@ -930,7 +930,14 @@ async def _resolve_existing_watchlist_item(
     now: datetime,
     event_raw: dict[str, Any] | None,
     enqueue_sync: bool = False,
+    restore_dropped: bool = True,
 ) -> tuple[WatchlistItem, str]:
+    if existing.status == "dropped" and not restore_dropped:
+        # Provider imports must not resurrect dropped items; un-dropping is
+        # driven by the provider's dropped list (reconcile) or a manual
+        # restore, otherwise an item present in both the provider watchlist
+        # and its dropped section would flip-flop on every import.
+        return existing, "already_exists"
     if existing.status in WATCHLIST_TERMINAL_STATUSES:
         was_dropped = existing.status == "dropped"
         initial_status = "added"
@@ -986,6 +993,7 @@ async def upsert_watchlist_item(
     now: datetime | None = None,
     event_raw: dict[str, Any] | None = None,
     enqueue_sync: bool = False,
+    restore_dropped: bool = True,
 ) -> tuple[WatchlistItem | None, str]:
     """
     Create, restore, or return a watchlist item.
@@ -994,6 +1002,11 @@ async def upsert_watchlist_item(
     to connected providers via the watchlist outbox. Callers that enqueue the
     push themselves (manual API add) or that must not echo items back out
     (watchlist imports) leave this False.
+
+    When restore_dropped is False, an existing dropped item is returned
+    untouched instead of being resurrected; provider imports use this so
+    dropped state stays sticky and is only lifted by the dropped-list
+    reconcile or a manual restore.
     """
     normalized_ids = normalize_media_ids(ids)
     if not normalized_ids:
@@ -1056,6 +1069,7 @@ async def upsert_watchlist_item(
             now=now,
             event_raw=event_raw,
             enqueue_sync=enqueue_sync,
+            restore_dropped=restore_dropped,
         )
 
     initial_status = "added"

--- a/backend/src/librarysync/core/watchlist_sources.py
+++ b/backend/src/librarysync/core/watchlist_sources.py
@@ -15,6 +15,7 @@ MANUAL_SOURCE_EXTERNAL_ID = "manual"
 PERSONAL_SOURCE_TYPE = "personal"
 URL_SOURCE_TYPE = "url"
 LEGACY_LIST_SOURCE_TYPE = "list"
+DROPPED_SOURCE_EXTERNAL_ID = "dropped"
 
 
 async def ensure_watchlist_source(
@@ -89,6 +90,39 @@ async def ensure_personal_watchlist_source(
         name=name,
         url=url,
     )
+
+
+async def ensure_dropped_watchlist_source(
+    db: AsyncSession,
+    user_id: str,
+    provider: str,
+    *,
+    name: str,
+) -> WatchlistSource:
+    return await ensure_watchlist_source(
+        db,
+        user_id=user_id,
+        provider=provider,
+        source_type=PERSONAL_SOURCE_TYPE,
+        external_id=DROPPED_SOURCE_EXTERNAL_ID,
+        name=name,
+    )
+
+
+def order_dropped_source_first(sources: list[WatchlistSource]) -> list[WatchlistSource]:
+    """Order the dropped source before all other sources.
+
+    Reconcile of the personal watchlist source may only run after dropped
+    items were linked to their own source, otherwise a show dropped on the
+    provider would be deleted and re-created on every import.
+    """
+    ordered = [
+        source
+        for source in sources
+        if source.source_type == PERSONAL_SOURCE_TYPE and source.external_id == DROPPED_SOURCE_EXTERNAL_ID
+    ]
+    ordered.extend(source for source in sources if source not in ordered)
+    return ordered
 
 
 async def list_watchlist_sources(

--- a/backend/src/librarysync/core/watchlist_sources.py
+++ b/backend/src/librarysync/core/watchlist_sources.py
@@ -6,8 +6,8 @@ from typing import Iterable
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from librarysync.core.watchlist import log_watchlist_event
-from librarysync.db.models import WatchlistItem, WatchlistSource, WatchlistSourceItem
+from librarysync.core.watchlist import evaluate_show_watchlist_status, log_watchlist_event
+from librarysync.db.models import MediaItem, WatchlistItem, WatchlistSource, WatchlistSourceItem
 
 MANUAL_SOURCE_PROVIDER = "manual"
 MANUAL_SOURCE_TYPE = "manual"
@@ -266,3 +266,94 @@ async def reconcile_watchlist_source(
     db.add(source)
     await db.commit()
     return removed_count
+
+
+async def reconcile_dropped_source(
+    db: AsyncSession,
+    source: WatchlistSource,
+    *,
+    now: datetime,
+    seen_item_ids: Iterable[str],
+) -> int:
+    """Reconcile a provider "dropped" source after a fetch.
+
+    Items no longer in the provider's dropped list lose the source link;
+    surviving items (manual or linked elsewhere) are un-dropped, orphaned
+    items are deleted — mirroring reconcile_watchlist_source, except that
+    survivors flip from "dropped" back to an evaluated status instead of
+    keeping a stale terminal state.
+    """
+    seen_set = {str(item_id) for item_id in seen_item_ids}
+    if seen_set:
+        stmt = select(WatchlistSourceItem).where(
+            WatchlistSourceItem.source_id == source.id,
+            WatchlistSourceItem.watchlist_item_id.notin_(seen_set),
+        )
+    else:
+        stmt = select(WatchlistSourceItem).where(WatchlistSourceItem.source_id == source.id)
+    result = await db.execute(stmt)
+    stale = result.scalars().all()
+    if not stale:
+        source.last_synced_at = now
+        db.add(source)
+        await db.commit()
+        return 0
+    restored_count = 0
+    watchlist_item_ids = {item.watchlist_item_id for item in stale}
+    await db.execute(
+        delete(WatchlistSourceItem).where(
+            WatchlistSourceItem.id.in_([item.id for item in stale])
+        )
+    )
+    for watchlist_item_id in watchlist_item_ids:
+        item_result = await db.execute(
+            select(WatchlistItem).where(WatchlistItem.id == watchlist_item_id)
+        )
+        watchlist_item = item_result.scalars().first()
+        if not watchlist_item:
+            continue
+        remaining = await db.execute(
+            select(WatchlistSourceItem.id).where(
+                WatchlistSourceItem.watchlist_item_id == watchlist_item_id
+            )
+        )
+        has_other_sources = remaining.scalars().first() is not None
+        if not has_other_sources and watchlist_item.source != "manual":
+            await log_watchlist_event(
+                db,
+                watchlist_item.user_id,
+                watchlist_item.media_item_id,
+                "watchlist_removed",
+                {"reason": "source_removed", "source_id": source.id},
+            )
+            await db.delete(watchlist_item)
+            continue
+        if watchlist_item.status != "dropped":
+            continue
+        watchlist_item.status = "added"
+        watchlist_item.updated_at = now
+        await log_watchlist_event(
+            db,
+            watchlist_item.user_id,
+            watchlist_item.media_item_id,
+            "watchlist_status_changed",
+            {
+                "status": "added",
+                "previous_status": "dropped",
+                "reason": f"{source.provider}_import",
+            },
+        )
+        if watchlist_item.type in {"tv", "anime"}:
+            media_result = await db.execute(
+                select(MediaItem).where(MediaItem.id == watchlist_item.media_item_id)
+            )
+            media_item = media_result.scalars().first()
+            if media_item:
+                await evaluate_show_watchlist_status(
+                    db, watchlist_item.user_id, watchlist_item, media_item
+                )
+        restored_count += 1
+    source.last_synced_at = now
+    db.add(source)
+    await db.commit()
+    return restored_count

--- a/backend/src/librarysync/core/watchlist_sync.py
+++ b/backend/src/librarysync/core/watchlist_sync.py
@@ -19,10 +19,12 @@ async def enqueue_personal_watchlist_sync(
     db: AsyncSession,
     watchlist_item: WatchlistItem,
     media_item: MediaItem | None,
+    *,
+    unhide_dropped: bool = False,
 ) -> None:
     if not media_item:
         return
-    await _enqueue_trakt_watchlist(db, watchlist_item, media_item)
+    await _enqueue_trakt_watchlist(db, watchlist_item, media_item, unhide_dropped=unhide_dropped)
     await _enqueue_simkl_watchlist(db, watchlist_item, media_item)
     await _enqueue_publicmetadb_watchlist(db, watchlist_item, media_item)
     await _enqueue_letterboxd_watchlist(db, watchlist_item, media_item)
@@ -120,6 +122,19 @@ def _build_trakt_payload(
     return payload
 
 
+def _build_trakt_removal_payload(
+    watchlist_item: WatchlistItem,
+    media_item: MediaItem,
+) -> dict[str, Any] | None:
+    payload = _build_trakt_payload(watchlist_item, media_item)
+    if payload is not None and watchlist_item.status == "dropped":
+        # Tells the delivery step to also hide the show in Trakt's dropped
+        # section (POST /users/hidden/dropped), not just remove the watchlist
+        # entry.
+        payload["dropped"] = True
+    return payload
+
+
 def _build_simkl_payload(
     watchlist_item: WatchlistItem,
     media_item: MediaItem,
@@ -178,7 +193,17 @@ async def _enqueue_trakt_watchlist(
     db: AsyncSession,
     watchlist_item: WatchlistItem,
     media_item: MediaItem,
+    *,
+    unhide_dropped: bool = False,
 ) -> None:
+    def build_payload(item: WatchlistItem, media: MediaItem) -> dict[str, Any] | None:
+        payload = _build_trakt_payload(item, media)
+        if payload is not None and unhide_dropped:
+            # Tells the delivery step to unhide the show from Trakt's dropped
+            # section (POST /users/hidden/dropped/remove) after re-adding it.
+            payload["unhide_dropped"] = True
+        return payload
+
     await _enqueue_watchlist_job(
         db,
         watchlist_item,
@@ -187,7 +212,7 @@ async def _enqueue_trakt_watchlist(
         source_name="Trakt watchlist",
         job_type="push_watchlist",
         required_fields=has_required_trakt_fields,
-        build_payload=_build_trakt_payload,
+        build_payload=build_payload,
     )
 
 
@@ -204,7 +229,7 @@ async def _enqueue_trakt_watchlist_removal(
         source_name="Trakt watchlist",
         job_type="remove_watchlist",
         required_fields=has_required_trakt_fields,
-        build_payload=_build_trakt_payload,
+        build_payload=_build_trakt_removal_payload,
     )
 
 

--- a/backend/src/librarysync/core/watchlist_sync.py
+++ b/backend/src/librarysync/core/watchlist_sync.py
@@ -133,9 +133,9 @@ def _build_simkl_payload(
         return None
     payload = _base_watchlist_payload(watchlist_item, media_item)
     payload["simkl_id"] = simkl_id
-    if watchlist_item.type in {"movie", "anime"}:
+    if watchlist_item.type == "movie":
         payload["movie_ids"] = ids
-    elif watchlist_item.type == "tv":
+    elif watchlist_item.type in {"tv", "anime"}:
         payload["show_ids"] = ids
     else:
         return None

--- a/backend/src/librarysync/core/watchlist_sync.py
+++ b/backend/src/librarysync/core/watchlist_sync.py
@@ -131,7 +131,7 @@ def _build_trakt_removal_payload(
         # Tells the delivery step to also hide the show in Trakt's dropped
         # section (POST /users/hidden/dropped), not just remove the watchlist
         # entry.
-        payload["dropped"] = True
+        payload["hide_dropped"] = True
     return payload
 
 
@@ -154,6 +154,19 @@ def _build_simkl_payload(
         payload["show_ids"] = ids
     else:
         return None
+    return payload
+
+
+def _build_simkl_removal_payload(
+    watchlist_item: WatchlistItem,
+    media_item: MediaItem,
+) -> dict[str, Any] | None:
+    payload = _build_simkl_payload(watchlist_item, media_item)
+    if payload is not None and watchlist_item.status == "dropped":
+        # Tells the delivery step to also move the show to SIMKL's dropped
+        # list (POST /sync/add-to-list with to=dropped), not just remove the
+        # watchlist entry.
+        payload["hide_dropped"] = True
     return payload
 
 
@@ -263,7 +276,7 @@ async def _enqueue_simkl_watchlist_removal(
         source_name="SIMKL watchlist",
         job_type="remove_watchlist",
         required_fields=has_required_simkl_fields,
-        build_payload=_build_simkl_payload,
+        build_payload=_build_simkl_removal_payload,
     )
 
 

--- a/backend/src/librarysync/db/models.py
+++ b/backend/src/librarysync/db/models.py
@@ -578,7 +578,7 @@ class WatchlistItem(Base):
     )
     # type: movie, show
     type: Mapped[str] = mapped_column(String(32))
-    # status: added, in_progress, watched, not_released, removed
+    # status: added, in_progress, watched, not_released, hidden, dropped, removed
     status: Mapped[str] = mapped_column(String(32), default="added", index=True)
     source: Mapped[str] = mapped_column(String(32), default="manual")
     rewatch_requested: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)

--- a/backend/src/librarysync/db/models.py
+++ b/backend/src/librarysync/db/models.py
@@ -413,7 +413,6 @@ class StremioCustomCatalog(Base):
             "slug",
             name="uq_stremio_custom_catalogs_user_slug",
         ),
-        Index("ix_stremio_custom_catalogs_user_id", "user_id"),
     )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
@@ -473,7 +472,6 @@ class StremioExternalCatalog(Base):
             "slug",
             name="uq_stremio_external_catalogs_user_slug",
         ),
-        Index("ix_stremio_external_catalogs_user_id", "user_id"),
     )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))

--- a/backend/src/librarysync/jobs/process_outbox.py
+++ b/backend/src/librarysync/jobs/process_outbox.py
@@ -1215,6 +1215,12 @@ async def _deliver_trakt_watchlist(
     access_token = await _ensure_trakt_access_token(db, integration.id, secret_data, client)
     watchlist_payload = _build_trakt_watchlist_payload(payload)
     _, response_code = await client.add_to_watchlist(watchlist_payload, access_token)
+    media_type = _coerce_str(payload.get("media_type")) or "movie"
+    if payload.get("unhide_dropped") and media_type in {"tv", "anime"}:
+        # A show restored from dropped must not stay hidden in Trakt's dropped
+        # section; unhide is a no-op when it was never dropped.
+        hidden_payload = _build_trakt_hidden_dropped_payload(payload)
+        await client.remove_hidden_items("dropped", hidden_payload, access_token)
     return response_code, None
 
 
@@ -1237,6 +1243,12 @@ async def _deliver_trakt_watchlist_remove(
     access_token = await _ensure_trakt_access_token(db, integration.id, secret_data, client)
     watchlist_payload = _build_trakt_watchlist_payload(payload)
     _, response_code = await client.remove_from_watchlist(watchlist_payload, access_token)
+    media_type = _coerce_str(payload.get("media_type")) or "movie"
+    if payload.get("dropped") and media_type in {"tv", "anime"}:
+        # Dropped shows are also hidden in Trakt's dropped section so they no
+        # longer show up in the user's progress on trakt.tv.
+        hidden_payload = _build_trakt_hidden_dropped_payload(payload)
+        await client.add_hidden_items("dropped", hidden_payload, access_token)
     return response_code, None
 
 
@@ -2519,6 +2531,25 @@ def _build_trakt_watchlist_payload(payload: dict[str, object]) -> dict[str, Any]
     return {"shows": [{"ids": show_ids}]}
 
 
+def _build_trakt_hidden_dropped_payload(payload: dict[str, object]) -> dict[str, Any]:
+    # Trakt's hidden "dropped" section only accepts show objects; anime series
+    # are shows on Trakt, so fall back to movie_ids where anime ids are stored.
+    show_ids = _normalize_trakt_ids(payload.get("show_ids"))
+    if not show_ids:
+        show_ids = _normalize_trakt_ids(payload.get("movie_ids"))
+    if not show_ids:
+        show_ids = _normalize_trakt_ids(
+            {
+                "imdb": payload.get("imdb_id"),
+                "tmdb": payload.get("tmdb_id"),
+                "tvdb": payload.get("tvdb_id"),
+            }
+        )
+    if not show_ids:
+        raise ValueError("Trakt hidden dropped sync requires show ids")
+    return {"shows": [{"ids": show_ids}]}
+
+
 def _build_simkl_watchlist_payload(payload: dict[str, object]) -> dict[str, Any]:
     media_type = _coerce_str(payload.get("media_type")) or "movie"
     if media_type == "movie":
@@ -2548,8 +2579,8 @@ def _build_simkl_watchlist_payload(payload: dict[str, object]) -> dict[str, Any]
         )
     if not show_ids:
         raise ValueError("SIMKL watchlist sync requires show ids")
-    container_key = "anime" if media_type == "anime" else "shows"
-    return {container_key: [{"ids": show_ids}]}
+    # SIMKL has no "anime" container for POST payloads; anime are shows too.
+    return {"shows": [{"ids": show_ids}]}
 
 
 def _build_simkl_drop_watchlist_payload(payload: dict[str, object]) -> dict[str, Any]:
@@ -2568,8 +2599,7 @@ def _build_simkl_drop_watchlist_payload(payload: dict[str, object]) -> dict[str,
         )
     if not show_ids:
         raise ValueError("SIMKL drop watchlist requires show ids")
-    container_key = "anime" if media_type == "anime" else "shows"
-    return {"to": "dropped", container_key: [{"ids": show_ids}]}
+    return {"to": "dropped", "shows": [{"ids": show_ids}]}
 
 
 def _build_trakt_remove_payload(payload: dict[str, object]) -> dict[str, Any]:

--- a/backend/src/librarysync/jobs/process_outbox.py
+++ b/backend/src/librarysync/jobs/process_outbox.py
@@ -2521,7 +2521,7 @@ def _build_trakt_watchlist_payload(payload: dict[str, object]) -> dict[str, Any]
 
 def _build_simkl_watchlist_payload(payload: dict[str, object]) -> dict[str, Any]:
     media_type = _coerce_str(payload.get("media_type")) or "movie"
-    if media_type in {"movie", "anime"}:
+    if media_type == "movie":
         movie_ids = _normalize_simkl_ids(payload.get("movie_ids"))
         if not movie_ids:
             movie_ids = _normalize_simkl_ids(
@@ -2548,7 +2548,8 @@ def _build_simkl_watchlist_payload(payload: dict[str, object]) -> dict[str, Any]
         )
     if not show_ids:
         raise ValueError("SIMKL watchlist sync requires show ids")
-    return {"shows": [{"ids": show_ids}]}
+    container_key = "anime" if media_type == "anime" else "shows"
+    return {container_key: [{"ids": show_ids}]}
 
 
 def _build_simkl_drop_watchlist_payload(payload: dict[str, object]) -> dict[str, Any]:

--- a/backend/src/librarysync/jobs/process_outbox.py
+++ b/backend/src/librarysync/jobs/process_outbox.py
@@ -1458,8 +1458,8 @@ async def _deliver_simkl_watchlist_remove(
         watchlist_payload = _build_simkl_drop_watchlist_payload(payload)
         _, response_code = await client.add_to_list(watchlist_payload, access_token)
     else:
-        watchlist_payload = _build_simkl_watchlist_payload(payload)
-        _, response_code = await client.remove_from_watchlist(watchlist_payload, access_token)
+        remove_payload = _build_simkl_watchlist_remove_payload(payload)
+        _, response_code = await client.remove_history(remove_payload, access_token)
     return response_code, None
 
 
@@ -2580,12 +2580,35 @@ def _build_simkl_watchlist_payload(payload: dict[str, object]) -> dict[str, Any]
             )
         if not movie_ids:
             raise ValueError("SIMKL watchlist sync requires movie ids")
-        return {"movies": [{"ids": movie_ids}]}
+        return {"movies": [{"ids": movie_ids, "to": "plantowatch"}]}
 
     show_ids = _resolve_simkl_show_ids(payload)
     if not show_ids:
         raise ValueError("SIMKL watchlist sync requires show ids")
     # SIMKL has no "anime" container for POST payloads; anime are shows too.
+    return {"shows": [{"ids": show_ids, "to": "plantowatch"}]}
+
+
+def _build_simkl_watchlist_remove_payload(payload: dict[str, object]) -> dict[str, Any]:
+    media_type = _coerce_str(payload.get("media_type")) or "movie"
+    if media_type == "movie":
+        movie_ids = _normalize_simkl_ids(payload.get("movie_ids"))
+        if not movie_ids:
+            movie_ids = _normalize_simkl_ids(
+                {
+                    "imdb": payload.get("imdb_id"),
+                    "tmdb": payload.get("tmdb_id"),
+                    "tvdb": payload.get("tvdb_id"),
+                    "simkl": payload.get("simkl_id"),
+                }
+            )
+        if not movie_ids:
+            raise ValueError("SIMKL watchlist removal requires movie ids")
+        return {"movies": [{"ids": movie_ids}]}
+
+    show_ids = _resolve_simkl_show_ids(payload)
+    if not show_ids:
+        raise ValueError("SIMKL watchlist removal requires show ids")
     return {"shows": [{"ids": show_ids}]}
 
 

--- a/backend/src/librarysync/jobs/process_outbox.py
+++ b/backend/src/librarysync/jobs/process_outbox.py
@@ -1244,7 +1244,7 @@ async def _deliver_trakt_watchlist_remove(
     watchlist_payload = _build_trakt_watchlist_payload(payload)
     _, response_code = await client.remove_from_watchlist(watchlist_payload, access_token)
     media_type = _coerce_str(payload.get("media_type")) or "movie"
-    if payload.get("dropped") and media_type in {"tv", "anime"}:
+    if payload.get("hide_dropped") and media_type in {"tv", "anime"}:
         # Dropped shows are also hidden in Trakt's dropped section so they no
         # longer show up in the user's progress on trakt.tv.
         hidden_payload = _build_trakt_hidden_dropped_payload(payload)
@@ -1452,7 +1452,9 @@ async def _deliver_simkl_watchlist_remove(
     )
     access_token = await _ensure_simkl_access_token(db, integration.id, secret_data, client)
     media_type = _coerce_str(payload.get("media_type")) or "movie"
-    if media_type in {"tv", "anime"}:
+    if payload.get("hide_dropped") and media_type in {"tv", "anime"}:
+        # Dropped shows are also moved to SIMKL's dropped list so they no
+        # longer show up in the user's watching list on simkl.com.
         watchlist_payload = _build_simkl_drop_watchlist_payload(payload)
         _, response_code = await client.add_to_list(watchlist_payload, access_token)
     else:
@@ -2501,6 +2503,33 @@ def _build_trakt_history_payload(
     raise ValueError("Trakt sync requires show or episode ids")
 
 
+def _resolve_trakt_show_ids(payload: dict[str, object]) -> dict[str, object]:
+    show_ids = _normalize_trakt_ids(payload.get("show_ids"))
+    if not show_ids:
+        show_ids = _normalize_trakt_ids(
+            {
+                "imdb": payload.get("imdb_id"),
+                "tmdb": payload.get("tmdb_id"),
+                "tvdb": payload.get("tvdb_id"),
+            }
+        )
+    return show_ids
+
+
+def _resolve_simkl_show_ids(payload: dict[str, object]) -> dict[str, object]:
+    show_ids = _normalize_simkl_ids(payload.get("show_ids"))
+    if not show_ids:
+        show_ids = _normalize_simkl_ids(
+            {
+                "imdb": payload.get("imdb_id"),
+                "tmdb": payload.get("tmdb_id"),
+                "tvdb": payload.get("tvdb_id"),
+                "simkl": payload.get("simkl_id"),
+            }
+        )
+    return show_ids
+
+
 def _build_trakt_watchlist_payload(payload: dict[str, object]) -> dict[str, Any]:
     media_type = _coerce_str(payload.get("media_type")) or "movie"
     if media_type in {"movie", "anime"}:
@@ -2517,15 +2546,7 @@ def _build_trakt_watchlist_payload(payload: dict[str, object]) -> dict[str, Any]
             raise ValueError("Trakt watchlist sync requires movie ids")
         return {"movies": [{"ids": movie_ids}]}
 
-    show_ids = _normalize_trakt_ids(payload.get("show_ids"))
-    if not show_ids:
-        show_ids = _normalize_trakt_ids(
-            {
-                "imdb": payload.get("imdb_id"),
-                "tmdb": payload.get("tmdb_id"),
-                "tvdb": payload.get("tvdb_id"),
-            }
-        )
+    show_ids = _resolve_trakt_show_ids(payload)
     if not show_ids:
         raise ValueError("Trakt watchlist sync requires show ids")
     return {"shows": [{"ids": show_ids}]}
@@ -2538,13 +2559,7 @@ def _build_trakt_hidden_dropped_payload(payload: dict[str, object]) -> dict[str,
     if not show_ids:
         show_ids = _normalize_trakt_ids(payload.get("movie_ids"))
     if not show_ids:
-        show_ids = _normalize_trakt_ids(
-            {
-                "imdb": payload.get("imdb_id"),
-                "tmdb": payload.get("tmdb_id"),
-                "tvdb": payload.get("tvdb_id"),
-            }
-        )
+        show_ids = _resolve_trakt_show_ids(payload)
     if not show_ids:
         raise ValueError("Trakt hidden dropped sync requires show ids")
     return {"shows": [{"ids": show_ids}]}
@@ -2567,16 +2582,7 @@ def _build_simkl_watchlist_payload(payload: dict[str, object]) -> dict[str, Any]
             raise ValueError("SIMKL watchlist sync requires movie ids")
         return {"movies": [{"ids": movie_ids}]}
 
-    show_ids = _normalize_simkl_ids(payload.get("show_ids"))
-    if not show_ids:
-        show_ids = _normalize_simkl_ids(
-            {
-                "imdb": payload.get("imdb_id"),
-                "tmdb": payload.get("tmdb_id"),
-                "tvdb": payload.get("tvdb_id"),
-                "simkl": payload.get("simkl_id"),
-            }
-        )
+    show_ids = _resolve_simkl_show_ids(payload)
     if not show_ids:
         raise ValueError("SIMKL watchlist sync requires show ids")
     # SIMKL has no "anime" container for POST payloads; anime are shows too.
@@ -2587,19 +2593,10 @@ def _build_simkl_drop_watchlist_payload(payload: dict[str, object]) -> dict[str,
     media_type = _coerce_str(payload.get("media_type")) or "movie"
     if media_type not in {"tv", "anime"}:
         raise ValueError("SIMKL drop watchlist requires tv or anime media type")
-    show_ids = _normalize_simkl_ids(payload.get("show_ids"))
-    if not show_ids:
-        show_ids = _normalize_simkl_ids(
-            {
-                "imdb": payload.get("imdb_id"),
-                "tmdb": payload.get("tmdb_id"),
-                "tvdb": payload.get("tvdb_id"),
-                "simkl": payload.get("simkl_id"),
-            }
-        )
+    show_ids = _resolve_simkl_show_ids(payload)
     if not show_ids:
         raise ValueError("SIMKL drop watchlist requires show ids")
-    return {"to": "dropped", "shows": [{"ids": show_ids}]}
+    return {"shows": [{"ids": show_ids, "to": "dropped"}]}
 
 
 def _build_trakt_remove_payload(payload: dict[str, object]) -> dict[str, Any]:

--- a/backend/src/librarysync/jobs/process_outbox.py
+++ b/backend/src/librarysync/jobs/process_outbox.py
@@ -1439,8 +1439,13 @@ async def _deliver_simkl_watchlist_remove(
         client_secret=settings.simkl_client_secret,
     )
     access_token = await _ensure_simkl_access_token(db, integration.id, secret_data, client)
-    watchlist_payload = _build_simkl_watchlist_payload(payload)
-    _, response_code = await client.remove_from_watchlist(watchlist_payload, access_token)
+    media_type = _coerce_str(payload.get("media_type")) or "movie"
+    if media_type in {"tv", "anime"}:
+        watchlist_payload = _build_simkl_drop_watchlist_payload(payload)
+        _, response_code = await client.add_to_list(watchlist_payload, access_token)
+    else:
+        watchlist_payload = _build_simkl_watchlist_payload(payload)
+        _, response_code = await client.remove_from_watchlist(watchlist_payload, access_token)
     return response_code, None
 
 
@@ -2546,6 +2551,26 @@ def _build_simkl_watchlist_payload(payload: dict[str, object]) -> dict[str, Any]
     return {"shows": [{"ids": show_ids}]}
 
 
+def _build_simkl_drop_watchlist_payload(payload: dict[str, object]) -> dict[str, Any]:
+    media_type = _coerce_str(payload.get("media_type")) or "movie"
+    if media_type not in {"tv", "anime"}:
+        raise ValueError("SIMKL drop watchlist requires tv or anime media type")
+    show_ids = _normalize_simkl_ids(payload.get("show_ids"))
+    if not show_ids:
+        show_ids = _normalize_simkl_ids(
+            {
+                "imdb": payload.get("imdb_id"),
+                "tmdb": payload.get("tmdb_id"),
+                "tvdb": payload.get("tvdb_id"),
+                "simkl": payload.get("simkl_id"),
+            }
+        )
+    if not show_ids:
+        raise ValueError("SIMKL drop watchlist requires show ids")
+    container_key = "anime" if media_type == "anime" else "shows"
+    return {"to": "dropped", container_key: [{"ids": show_ids}]}
+
+
 def _build_trakt_remove_payload(payload: dict[str, object]) -> dict[str, Any]:
     media_type = _coerce_str(payload.get("media_type")) or "movie"
     if media_type == "movie":
@@ -2762,7 +2787,8 @@ def _normalize_simkl_ids(value: object) -> dict[str, object]:
         if key == "imdb":
             ids[key] = str(entry).lower()
         else:
-            ids[key] = entry
+            parsed_int = _coerce_int(entry)
+            ids[key] = parsed_int if parsed_int is not None else entry
     return ids
 
 

--- a/backend/src/librarysync/jobs/simkl_import.py
+++ b/backend/src/librarysync/jobs/simkl_import.py
@@ -26,6 +26,7 @@ from librarysync.core.security import encrypt_value
 from librarysync.core.watchlist_sources import (
     PERSONAL_SOURCE_TYPE,
     ensure_personal_watchlist_source,
+    ensure_watchlist_source,
     list_watchlist_sources,
     reconcile_watchlist_source,
 )
@@ -47,6 +48,7 @@ from librarysync.jobs.import_pipeline import (
 from librarysync.jobs.import_utils import chunked
 from librarysync.jobs.watchlist_pipeline import (
     WatchlistCandidate,
+    process_dropped_candidates,
     process_watchlist_candidates,
 )
 
@@ -65,6 +67,7 @@ WATCHLIST_STATUSES = {
     "planned",
     "watchlist",
 }
+DROPPED_STATUSES = {"dropped"}
 
 
 @dataclass(frozen=True)
@@ -496,13 +499,40 @@ async def _import_watchlist_for_integration(
         provider="simkl",
         name="SIMKL watchlist",
     )
+    await ensure_watchlist_source(
+        db,
+        user_id=integration.user_id,
+        provider="simkl",
+        source_type=PERSONAL_SOURCE_TYPE,
+        external_id="dropped",
+        name="SIMKL dropped",
+    )
     if sources is None:
         sources = await list_watchlist_sources(db, integration.user_id, provider="simkl")
     if not sources:
         return 0
+    # Dropped pass first: reconcile of the personal watchlist source may only
+    # run after dropped items were linked to their own source, otherwise a
+    # show dropped on SIMKL would be deleted and re-created on every import.
+    ordered_sources = [
+        source
+        for source in sources
+        if source.source_type == PERSONAL_SOURCE_TYPE and source.external_id == "dropped"
+    ]
+    ordered_sources.extend(source for source in sources if source not in ordered_sources)
     imported = 0
-    for source in sources:
+    for source in ordered_sources:
         if source.source_type != PERSONAL_SOURCE_TYPE:
+            continue
+        if source.external_id == "dropped":
+            imported += await _import_dropped_for_source(
+                db,
+                integration,
+                client,
+                access_token,
+                source,
+                now,
+            )
             continue
         candidates: list[WatchlistCandidate] = []
         total_entries = 0
@@ -548,6 +578,60 @@ async def _import_watchlist_for_integration(
                 seen_item_ids=[],
             )
     return imported
+
+
+async def _import_dropped_for_source(
+    db: AsyncSession,
+    integration: Integration,
+    client: SimklClient,
+    access_token: str,
+    source: WatchlistSource,
+    now: datetime,
+) -> int:
+    # Dropped movies are not ingested: the dropped status only exists for
+    # tv/anime in librarySync.
+    candidates: list[WatchlistCandidate] = []
+    total_entries = 0
+    for category in ("shows", "anime"):
+        try:
+            payload = await client.fetch_all_items(
+                access_token,
+                category=category,
+                extended="full",
+            )
+        except SimklError as exc:
+            logger.warning(
+                "SIMKL dropped fetch failed for user %s (%s): %s",
+                integration.user_id,
+                category,
+                exc,
+            )
+            continue
+        entries = _extract_all_items_entries(payload, category, DROPPED_STATUSES)
+        total_entries += len(entries)
+        for entry in entries:
+            show = _extract_show_summary(entry)
+            if not show:
+                continue
+            candidate = _build_watchlist_show_candidate(
+                entry,
+                show,
+                source="simkl",
+                list_context={"name": "SIMKL dropped", "type": "personal"},
+            )
+            if candidate:
+                candidates.append(candidate)
+    if not candidates and total_entries:
+        # Entries existed but none could be parsed; skip reconcile defensively.
+        return 0
+    return await process_dropped_candidates(
+        db,
+        integration.user_id,
+        "simkl",
+        source,
+        candidates,
+        now=now,
+    )
 
 
 async def import_watchlist_source(

--- a/backend/src/librarysync/jobs/simkl_import.py
+++ b/backend/src/librarysync/jobs/simkl_import.py
@@ -24,10 +24,12 @@ from librarysync.core.integrations import load_integration_with_secrets
 from librarysync.core.ratings import normalize_ten_point_rating
 from librarysync.core.security import encrypt_value
 from librarysync.core.watchlist_sources import (
+    DROPPED_SOURCE_EXTERNAL_ID,
     PERSONAL_SOURCE_TYPE,
+    ensure_dropped_watchlist_source,
     ensure_personal_watchlist_source,
-    ensure_watchlist_source,
     list_watchlist_sources,
+    order_dropped_source_first,
     reconcile_watchlist_source,
 )
 from librarysync.db.models import (
@@ -485,6 +487,38 @@ async def _import_shows_payload(
     return imported
 
 
+async def _fetch_all_items_cached(
+    client: SimklClient,
+    access_token: str,
+    category: str,
+    payloads: dict[str, dict[str, Any] | None],
+    *,
+    user_id: str,
+) -> dict[str, Any] | None:
+    """Fetch /sync/all-items once per category per import run.
+
+    The dropped pass and the watchlist pass share the same payload; a failed
+    fetch is cached as None so both passes observe the same failure.
+    """
+    if category in payloads:
+        return payloads[category]
+    try:
+        payloads[category] = await client.fetch_all_items(
+            access_token,
+            category=category,
+            extended="full" if category in {"shows", "anime"} else None,
+        )
+    except SimklError as exc:
+        logger.warning(
+            "SIMKL all-items fetch failed for user %s (%s): %s",
+            user_id,
+            category,
+            exc,
+        )
+        payloads[category] = None
+    return payloads[category]
+
+
 async def _import_watchlist_for_integration(
     db: AsyncSession,
     integration: Integration,
@@ -499,32 +533,25 @@ async def _import_watchlist_for_integration(
         provider="simkl",
         name="SIMKL watchlist",
     )
-    await ensure_watchlist_source(
+    await ensure_dropped_watchlist_source(
         db,
-        user_id=integration.user_id,
-        provider="simkl",
-        source_type=PERSONAL_SOURCE_TYPE,
-        external_id="dropped",
+        integration.user_id,
+        "simkl",
         name="SIMKL dropped",
     )
     if sources is None:
         sources = await list_watchlist_sources(db, integration.user_id, provider="simkl")
     if not sources:
         return 0
-    # Dropped pass first: reconcile of the personal watchlist source may only
-    # run after dropped items were linked to their own source, otherwise a
-    # show dropped on SIMKL would be deleted and re-created on every import.
-    ordered_sources = [
-        source
-        for source in sources
-        if source.source_type == PERSONAL_SOURCE_TYPE and source.external_id == "dropped"
-    ]
-    ordered_sources.extend(source for source in sources if source not in ordered_sources)
+    ordered_sources = order_dropped_source_first(sources)
     imported = 0
+    # /sync/all-items is fetched once per category and shared between the
+    # dropped pass and the watchlist pass below.
+    payloads: dict[str, dict[str, Any] | None] = {}
     for source in ordered_sources:
         if source.source_type != PERSONAL_SOURCE_TYPE:
             continue
-        if source.external_id == "dropped":
+        if source.external_id == DROPPED_SOURCE_EXTERNAL_ID:
             imported += await _import_dropped_for_source(
                 db,
                 integration,
@@ -532,24 +559,20 @@ async def _import_watchlist_for_integration(
                 access_token,
                 source,
                 now,
+                payloads=payloads,
             )
             continue
         candidates: list[WatchlistCandidate] = []
         total_entries = 0
         for category in ("movies", "shows", "anime"):
-            try:
-                payload = await client.fetch_all_items(
-                    access_token,
-                    category=category,
-                    extended="full" if category in {"shows", "anime"} else None,
-                )
-            except SimklError as exc:
-                logger.warning(
-                    "SIMKL watchlist fetch failed for user %s (%s): %s",
-                    integration.user_id,
-                    category,
-                    exc,
-                )
+            payload = await _fetch_all_items_cached(
+                client,
+                access_token,
+                category,
+                payloads,
+                user_id=integration.user_id,
+            )
+            if payload is None:
                 continue
             entries = _extract_all_items_entries(payload, category, WATCHLIST_STATUSES)
             total_entries += len(entries)
@@ -587,26 +610,27 @@ async def _import_dropped_for_source(
     access_token: str,
     source: WatchlistSource,
     now: datetime,
+    *,
+    payloads: dict[str, dict[str, Any] | None] | None = None,
 ) -> int:
     # Dropped movies are not ingested: the dropped status only exists for
     # tv/anime in librarySync.
+    if payloads is None:
+        payloads = {}
     candidates: list[WatchlistCandidate] = []
     total_entries = 0
     for category in ("shows", "anime"):
-        try:
-            payload = await client.fetch_all_items(
-                access_token,
-                category=category,
-                extended="full",
-            )
-        except SimklError as exc:
-            logger.warning(
-                "SIMKL dropped fetch failed for user %s (%s): %s",
-                integration.user_id,
-                category,
-                exc,
-            )
-            continue
+        payload = await _fetch_all_items_cached(
+            client,
+            access_token,
+            category,
+            payloads,
+            user_id=integration.user_id,
+        )
+        if payload is None:
+            # Never reconcile after a failed fetch: an empty seen set would
+            # un-drop/delete every SIMKL-dropped item on a transient error.
+            return 0
         entries = _extract_all_items_entries(payload, category, DROPPED_STATUSES)
         total_entries += len(entries)
         for entry in entries:

--- a/backend/src/librarysync/jobs/trakt_import.py
+++ b/backend/src/librarysync/jobs/trakt_import.py
@@ -27,6 +27,7 @@ from librarysync.core.watchlist_sources import (
     PERSONAL_SOURCE_TYPE,
     URL_SOURCE_TYPE,
     ensure_personal_watchlist_source,
+    ensure_watchlist_source,
     list_watchlist_sources,
     reconcile_watchlist_source,
 )
@@ -47,6 +48,7 @@ from librarysync.jobs.import_pipeline import (
 from librarysync.jobs.import_utils import chunked
 from librarysync.jobs.watchlist_pipeline import (
     WatchlistCandidate,
+    process_dropped_candidates,
     process_watchlist_candidates,
 )
 
@@ -230,14 +232,42 @@ async def _import_watchlist_for_integration(
         provider="trakt",
         name="Trakt watchlist",
     )
+    await ensure_watchlist_source(
+        db,
+        user_id=integration.user_id,
+        provider="trakt",
+        source_type=PERSONAL_SOURCE_TYPE,
+        external_id="dropped",
+        name="Trakt dropped",
+    )
     if sources is None:
         sources = await list_watchlist_sources(db, integration.user_id, provider="trakt")
     if not sources:
         return 0
+    # Dropped pass first: reconcile of the personal watchlist source may only
+    # run after dropped items were linked to their own source, otherwise a
+    # show dropped on Trakt would be deleted and re-created on every import.
+    ordered_sources = [
+        source
+        for source in sources
+        if source.source_type == PERSONAL_SOURCE_TYPE and source.external_id == "dropped"
+    ]
+    ordered_sources.extend(source for source in sources if source not in ordered_sources)
     candidates: list[WatchlistCandidate] = []
     imported = 0
     max_pages = None if lookback_days < 0 else WATCHLIST_MAX_PAGES
-    for source in sources:
+    for source in ordered_sources:
+        if source.source_type == PERSONAL_SOURCE_TYPE and source.external_id == "dropped":
+            imported += await _import_dropped_for_source(
+                db,
+                integration,
+                client,
+                access_token,
+                source,
+                now,
+                max_pages,
+            )
+            continue
         if source.source_type == PERSONAL_SOURCE_TYPE:
             total_entries = 0
             for watchlist_type in ("movies", "shows"):
@@ -343,6 +373,56 @@ async def _import_watchlist_for_integration(
             )
             candidates = []
     return imported
+
+
+async def _import_dropped_for_source(
+    db: AsyncSession,
+    integration: Integration,
+    client: TraktClient,
+    access_token: str,
+    source: WatchlistSource,
+    now: datetime,
+    max_pages: int | None,
+) -> int:
+    try:
+        entries = await client.get_hidden_items(
+            access_token,
+            section="dropped",
+            item_type="show",
+            per_page=WATCHLIST_PER_PAGE,
+            max_pages=max_pages,
+        )
+    except TraktError as exc:
+        logger.warning(
+            "Trakt dropped fetch failed for user %s: %s",
+            integration.user_id,
+            exc,
+        )
+        return 0
+    candidates: list[WatchlistCandidate] = []
+    for entry in entries:
+        show = _extract_show_summary(entry)
+        if not show:
+            continue
+        candidate = _build_watchlist_show_candidate(
+            entry,
+            show,
+            source="trakt",
+            list_context={"name": "Trakt dropped", "type": "personal"},
+        )
+        if candidate:
+            candidates.append(candidate)
+    if not candidates and entries:
+        # Entries existed but none could be parsed; skip reconcile defensively.
+        return 0
+    return await process_dropped_candidates(
+        db,
+        integration.user_id,
+        "trakt",
+        source,
+        candidates,
+        now=now,
+    )
 
 
 async def import_watchlist_source(

--- a/backend/src/librarysync/jobs/trakt_import.py
+++ b/backend/src/librarysync/jobs/trakt_import.py
@@ -23,12 +23,14 @@ from librarysync.core.ratings import normalize_ten_point_rating
 from librarysync.core.security import encrypt_value
 from librarysync.core.watchlist_links import TraktListRef, parse_trakt_list_urls
 from librarysync.core.watchlist_sources import (
+    DROPPED_SOURCE_EXTERNAL_ID,
     LEGACY_LIST_SOURCE_TYPE,
     PERSONAL_SOURCE_TYPE,
     URL_SOURCE_TYPE,
+    ensure_dropped_watchlist_source,
     ensure_personal_watchlist_source,
-    ensure_watchlist_source,
     list_watchlist_sources,
+    order_dropped_source_first,
     reconcile_watchlist_source,
 )
 from librarysync.db.models import (
@@ -232,32 +234,22 @@ async def _import_watchlist_for_integration(
         provider="trakt",
         name="Trakt watchlist",
     )
-    await ensure_watchlist_source(
+    await ensure_dropped_watchlist_source(
         db,
-        user_id=integration.user_id,
-        provider="trakt",
-        source_type=PERSONAL_SOURCE_TYPE,
-        external_id="dropped",
+        integration.user_id,
+        "trakt",
         name="Trakt dropped",
     )
     if sources is None:
         sources = await list_watchlist_sources(db, integration.user_id, provider="trakt")
     if not sources:
         return 0
-    # Dropped pass first: reconcile of the personal watchlist source may only
-    # run after dropped items were linked to their own source, otherwise a
-    # show dropped on Trakt would be deleted and re-created on every import.
-    ordered_sources = [
-        source
-        for source in sources
-        if source.source_type == PERSONAL_SOURCE_TYPE and source.external_id == "dropped"
-    ]
-    ordered_sources.extend(source for source in sources if source not in ordered_sources)
+    ordered_sources = order_dropped_source_first(sources)
     candidates: list[WatchlistCandidate] = []
     imported = 0
     max_pages = None if lookback_days < 0 else WATCHLIST_MAX_PAGES
     for source in ordered_sources:
-        if source.source_type == PERSONAL_SOURCE_TYPE and source.external_id == "dropped":
+        if source.source_type == PERSONAL_SOURCE_TYPE and source.external_id == DROPPED_SOURCE_EXTERNAL_ID:
             imported += await _import_dropped_for_source(
                 db,
                 integration,
@@ -265,7 +257,6 @@ async def _import_watchlist_for_integration(
                 access_token,
                 source,
                 now,
-                max_pages,
             )
             continue
         if source.source_type == PERSONAL_SOURCE_TYPE:
@@ -382,15 +373,16 @@ async def _import_dropped_for_source(
     access_token: str,
     source: WatchlistSource,
     now: datetime,
-    max_pages: int | None,
 ) -> int:
     try:
+        # The dropped list has no lookback semantics and reconcile un-drops
+        # shows missing from it, so it is always fetched without a page cap.
         entries = await client.get_hidden_items(
             access_token,
             section="dropped",
             item_type="show",
             per_page=WATCHLIST_PER_PAGE,
-            max_pages=max_pages,
+            max_pages=None,
         )
     except TraktError as exc:
         logger.warning(

--- a/backend/src/librarysync/jobs/watchlist_pipeline.py
+++ b/backend/src/librarysync/jobs/watchlist_pipeline.py
@@ -6,8 +6,13 @@ from typing import Any, Iterable, Literal
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from librarysync.core.watchlist import upsert_watchlist_item
+from librarysync.core.watchlist import (
+    clear_watchlist_rewatch_request,
+    log_watchlist_event,
+    upsert_watchlist_item,
+)
 from librarysync.core.watchlist_sources import (
+    reconcile_dropped_source,
     reconcile_watchlist_source,
     upsert_watchlist_source_item,
 )
@@ -76,6 +81,7 @@ async def process_watchlist_candidates(
             candidate.source,
             now=now,
             event_raw={"provider": provider},
+            restore_dropped=False,
         )
         if not item:
             continue
@@ -103,6 +109,90 @@ async def process_watchlist_candidates(
     if commit and not reconcile:
         await db.commit()
     return imported
+
+
+async def process_dropped_candidates(
+    db: AsyncSession,
+    user_id: str,
+    provider: str,
+    source: WatchlistSource,
+    candidates: Iterable[WatchlistCandidate],
+    *,
+    now: datetime | None = None,
+    commit: bool = True,
+    reconcile: bool = True,
+) -> int:
+    """Mark provider-dropped shows as dropped locally.
+
+    Mirrors process_watchlist_candidates, but items keep/gain the terminal
+    "dropped" status and the dropped source is reconciled so shows that leave
+    the provider's dropped list are un-dropped (or removed when orphaned).
+    Never enqueues provider sync — dropped state flows in, not back out.
+    """
+    candidate_list = [candidate for candidate in candidates if candidate.ids]
+    if now is None:
+        now = datetime.now(timezone.utc)
+    seen: set[str] = set()
+    marked = 0
+    seen_item_ids: list[str] = []
+    for candidate in candidate_list:
+        entry_key = candidate.entry_key or _build_fallback_key(candidate)
+        if entry_key in seen:
+            continue
+        seen.add(entry_key)
+        item, _status = await upsert_watchlist_item(
+            db,
+            user_id,
+            candidate.media_type,
+            candidate.ids,
+            candidate.title,
+            candidate.year,
+            candidate.poster_url,
+            candidate.source,
+            now=now,
+            event_raw={"provider": provider},
+            restore_dropped=False,
+        )
+        if not item:
+            continue
+        await upsert_watchlist_source_item(
+            db,
+            source,
+            item,
+            external_item_id=candidate.external_item_id,
+            now=now,
+        )
+        seen_item_ids.append(item.id)
+        if item.status == "dropped":
+            continue
+        previous_status = item.status
+        await clear_watchlist_rewatch_request(
+            db,
+            item,
+            user_id,
+            item.media_item_id,
+            reason="dropped",
+            now=now,
+        )
+        item.status = "dropped"
+        item.updated_at = now
+        await log_watchlist_event(
+            db,
+            user_id,
+            item.media_item_id,
+            "watchlist_status_changed",
+            {
+                "status": "dropped",
+                "previous_status": previous_status,
+                "reason": f"{provider}_import",
+            },
+        )
+        marked += 1
+    if reconcile:
+        await reconcile_dropped_source(db, source, now=now, seen_item_ids=seen_item_ids)
+    if commit and not reconcile:
+        await db.commit()
+    return marked
 
 
 def _build_fallback_key(candidate: WatchlistCandidate) -> str:

--- a/backend/src/librarysync/jobs/watchlist_pipeline.py
+++ b/backend/src/librarysync/jobs/watchlist_pipeline.py
@@ -7,8 +7,7 @@ from typing import Any, Iterable, Literal
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from librarysync.core.watchlist import (
-    clear_watchlist_rewatch_request,
-    log_watchlist_event,
+    mark_watchlist_item_dropped,
     upsert_watchlist_item,
 )
 from librarysync.core.watchlist_sources import (
@@ -165,27 +164,13 @@ async def process_dropped_candidates(
         seen_item_ids.append(item.id)
         if item.status == "dropped":
             continue
-        previous_status = item.status
-        await clear_watchlist_rewatch_request(
+        await mark_watchlist_item_dropped(
             db,
             item,
             user_id,
             item.media_item_id,
-            reason="dropped",
+            reason=f"{provider}_import",
             now=now,
-        )
-        item.status = "dropped"
-        item.updated_at = now
-        await log_watchlist_event(
-            db,
-            user_id,
-            item.media_item_id,
-            "watchlist_status_changed",
-            {
-                "status": "dropped",
-                "previous_status": previous_status,
-                "reason": f"{provider}_import",
-            },
         )
         marked += 1
     if reconcile:

--- a/backend/src/librarysync/static/page-watchlist.js
+++ b/backend/src/librarysync/static/page-watchlist.js
@@ -527,7 +527,9 @@ async function loadWatchlist() {
             }
         });
         menuPanel.appendChild(restoreButton);
-    } else if (item.media_type === "tv" || item.media_type === "anime") {
+    }
+
+    if (item.status !== "dropped" && (item.media_type === "tv" || item.media_type === "anime")) {
         // TV / Anime: Drop sends POST (marks as dropped, keeps the item)
         const dropButton = document.createElement("button");
         dropButton.type = "button";
@@ -546,7 +548,7 @@ async function loadWatchlist() {
         });
         menuPanel.appendChild(dropButton);
     } else {
-        // Movies: Remove deletes the item entirely
+        // Movies and dropped items: Remove deletes the item entirely
         const removeButton = document.createElement("button");
         removeButton.type = "button";
         removeButton.className = "danger-button";
@@ -568,9 +570,7 @@ async function loadWatchlist() {
     if (item.rewatch_requested) {
       badgeGroup.appendChild(rewatchBadge);
     }
-    if (item.status === "dropped") {
-      badgeGroup.appendChild(pill);
-    } else if (card.classList.contains("is-watched")) {
+    if (card.classList.contains("is-watched")) {
       badgeGroup.appendChild(pill);
     }
     if (badgeGroup.childElementCount > 0) {

--- a/backend/src/librarysync/static/page-watchlist.js
+++ b/backend/src/librarysync/static/page-watchlist.js
@@ -31,6 +31,7 @@ const WATCHLIST_STATUS_LABELS = {
   in_progress: "In progress",
   watched: "Watched",
   not_released: "Not released yet",
+  dropped: "Dropped",
   active: "Added",
   waiting: "Watched",
 };
@@ -54,6 +55,8 @@ function formatWatchlistSources(sources) {
 
 function isWatchlistRewatchEligible(item) {
   if (!item) return false;
+  // Dropped items are not rewatch-eligible
+  if (item.status === "dropped") return false;
   if (item.media_type === "movie") {
     return item.status === "watched" || item.status === "waiting";
   }
@@ -87,7 +90,7 @@ function buildWatchlistQueryParams() {
   
   // Logic for Status + Watched Display
   if (watchlistState.filters.status === "all") {
-      // All means Added + In Progress + Not Released + (Watched depending on display)
+      // "All" excludes dropped — those are opt-in via the Dropped filter.
       // Include legacy statuses to backfill existing items.
       const statuses = ["added", "in_progress", "not_released", "active", "waiting"];
       if (watchlistState.filters.watchedDisplay !== "hide") {
@@ -95,7 +98,7 @@ function buildWatchlistQueryParams() {
       }
       params.set("status", statuses.join(","));
   } else {
-      // Specific status selected
+      // Specific status selected (includes "dropped" when chosen explicitly)
       params.set("status", watchlistState.filters.status);
   }
 
@@ -296,6 +299,10 @@ async function loadWatchlist() {
     if (item.status === "added") badgeClass = "badge-success";
     if (item.status === "in_progress") badgeClass = "badge-warning";
     if (item.status === "not_released") badgeClass = "badge-neutral";
+    if (item.status === "dropped") {
+        badgeClass = "badge-neutral";
+        card.classList.add("is-watched"); // Reuse watched overlay styling for dropped items
+    }
     if (item.status === "watched" || item.status === "waiting") {
         badgeClass = "badge-neutral";
         if (watchlistState.filters.watchedDisplay === "overlay") {
@@ -343,7 +350,11 @@ async function loadWatchlist() {
 
     const pill = document.createElement("span");
     pill.className = "watchlist-pill";
-    pill.textContent = item.media_type === "tv" ? "Caught up" : "Watched";
+    if (item.status === "dropped") {
+      pill.textContent = "Dropped";
+    } else {
+      pill.textContent = item.media_type === "tv" ? "Caught up" : "Watched";
+    }
 
     const rewatchBadge = document.createElement("span");
     rewatchBadge.className = "watchlist-pill";
@@ -372,11 +383,13 @@ async function loadWatchlist() {
     menuPanel.setAttribute("role", "menu");
     menuPanel.setAttribute("data-menu-panel", "true");
 
-    // Add "Mark watched" button
+    // Add "Mark watched" button — not shown for dropped items
     let showMarkWatched = true;
     let markWatchedLabel = "Mark watched";
-    
-    if (item.media_type === "tv") {
+
+    if (item.status === "dropped") {
+        showMarkWatched = false;
+    } else if (item.media_type === "tv") {
         if (item.status === "watched" || item.status === "waiting") {
             showMarkWatched = false; // Already fully watched
         } else if (item.progress && item.progress.watched >= item.progress.total && item.progress.total > 0) {
@@ -494,32 +507,70 @@ async function loadWatchlist() {
         menuPanel.appendChild(rewatchButton);
     }
 
-    const deleteButton = document.createElement("button");
-    deleteButton.type = "button";
-    deleteButton.className = "danger-button";
-    const removeActionLabel = item.media_type === "tv" || item.media_type === "anime" ? "Drop" : "Remove";
-    deleteButton.textContent = removeActionLabel;
-    deleteButton.setAttribute("role", "menuitem");
-    deleteButton.addEventListener("click", async () => {
-        closeWatchlistMenus();
-        if (!confirm(`${removeActionLabel} "${item.title}" from watchlist?`)) return;
-        try {
-            await requestJSON(`/api/watchlist/items/${item.id}`, { method: "DELETE" });
-            await loadWatchlist();
-        } catch(e) {
-            alert(e.message);
-        }
-    });
-
     menuPanel.appendChild(metadataButton);
     menuPanel.appendChild(refreshMetadataButton);
     externalLinks.forEach((link) => menuPanel.appendChild(link));
-    menuPanel.appendChild(deleteButton);
+
+    if (item.status === "dropped") {
+        // Restore action: remove the dropped flag and return to normal status
+        const restoreButton = document.createElement("button");
+        restoreButton.type = "button";
+        restoreButton.textContent = "Restore to watchlist";
+        restoreButton.setAttribute("role", "menuitem");
+        restoreButton.addEventListener("click", async () => {
+            closeWatchlistMenus();
+            try {
+                await requestJSON(`/api/watchlist/items/${item.id}/drop`, { method: "DELETE" });
+                await loadWatchlist();
+            } catch (e) {
+                alert(e.message);
+            }
+        });
+        menuPanel.appendChild(restoreButton);
+    } else if (item.media_type === "tv" || item.media_type === "anime") {
+        // TV / Anime: Drop sends POST (marks as dropped, keeps the item)
+        const dropButton = document.createElement("button");
+        dropButton.type = "button";
+        dropButton.className = "danger-button";
+        dropButton.textContent = "Drop";
+        dropButton.setAttribute("role", "menuitem");
+        dropButton.addEventListener("click", async () => {
+            closeWatchlistMenus();
+            if (!confirm(`Drop "${item.title}"? It will stay in your watchlist as dropped.`)) return;
+            try {
+                await requestJSON(`/api/watchlist/items/${item.id}/drop`, { method: "POST" });
+                await loadWatchlist();
+            } catch (e) {
+                alert(e.message);
+            }
+        });
+        menuPanel.appendChild(dropButton);
+    } else {
+        // Movies: Remove deletes the item entirely
+        const removeButton = document.createElement("button");
+        removeButton.type = "button";
+        removeButton.className = "danger-button";
+        removeButton.textContent = "Remove";
+        removeButton.setAttribute("role", "menuitem");
+        removeButton.addEventListener("click", async () => {
+            closeWatchlistMenus();
+            if (!confirm(`Remove "${item.title}" from watchlist?`)) return;
+            try {
+                await requestJSON(`/api/watchlist/items/${item.id}`, { method: "DELETE" });
+                await loadWatchlist();
+            } catch (e) {
+                alert(e.message);
+            }
+        });
+        menuPanel.appendChild(removeButton);
+    }
     
     if (item.rewatch_requested) {
       badgeGroup.appendChild(rewatchBadge);
     }
-    if (card.classList.contains("is-watched")) {
+    if (item.status === "dropped") {
+      badgeGroup.appendChild(pill);
+    } else if (card.classList.contains("is-watched")) {
       badgeGroup.appendChild(pill);
     }
     if (badgeGroup.childElementCount > 0) {

--- a/backend/src/librarysync/static/page-watchlist.js
+++ b/backend/src/librarysync/static/page-watchlist.js
@@ -497,11 +497,12 @@ async function loadWatchlist() {
     const deleteButton = document.createElement("button");
     deleteButton.type = "button";
     deleteButton.className = "danger-button";
-    deleteButton.textContent = "Remove";
+    const removeActionLabel = item.media_type === "tv" || item.media_type === "anime" ? "Drop" : "Remove";
+    deleteButton.textContent = removeActionLabel;
     deleteButton.setAttribute("role", "menuitem");
     deleteButton.addEventListener("click", async () => {
         closeWatchlistMenus();
-        if (!confirm(`Remove "${item.title}" from watchlist?`)) return;
+        if (!confirm(`${removeActionLabel} "${item.title}" from watchlist?`)) return;
         try {
             await requestJSON(`/api/watchlist/items/${item.id}`, { method: "DELETE" });
             await loadWatchlist();

--- a/backend/src/librarysync/templates/watchlist.html
+++ b/backend/src/librarysync/templates/watchlist.html
@@ -25,6 +25,7 @@
               <option value="in_progress">In progress</option>
               <option value="watched">Watched</option>
               <option value="not_released">Not released yet</option>
+              <option value="dropped">Dropped</option>
             </select>
           </label>
           <label class="field min-w-[160px]">

--- a/backend/tests/test_stremio_addon_catalogs.py
+++ b/backend/tests/test_stremio_addon_catalogs.py
@@ -146,6 +146,26 @@ class TestStremioAddonCatalogs(unittest.TestCase):
         self.assertIn("watchlist_items.rewatch_requested is true", compiled)
         self.assertIn("case", compiled)
 
+    def test_watchlist_query_excludes_dropped_items(self) -> None:
+        catalog = {"media_type": "movie", "filters": {"statuses": []}}
+        query = asyncio.run(
+            routes_stremio_addon_public._build_watchlist_query("user-id", catalog, None)
+        )
+
+        compiled = str(query.compile(compile_kwargs={"literal_binds": True})).lower()
+        self.assertIn("watchlist_items.status not in", compiled)
+        self.assertIn("dropped", compiled)
+
+    def test_in_progress_query_excludes_dropped_items(self) -> None:
+        catalog = {"filters": {"statuses": ["added"]}}
+        query = asyncio.run(
+            routes_stremio_addon_public._build_in_progress_query("user-id", catalog, None)
+        )
+
+        compiled = str(query.compile(compile_kwargs={"literal_binds": True})).lower()
+        self.assertIn("watchlist_items.status not in", compiled)
+        self.assertIn("dropped", compiled)
+
     def test_slugify_normalizes(self) -> None:
         self.assertEqual(routes_stremio_addon._slugify("Curated Picks!"), "curated-picks")
 

--- a/backend/tests/test_watch_pipeline_show_watchlist.py
+++ b/backend/tests/test_watch_pipeline_show_watchlist.py
@@ -55,10 +55,10 @@ def _make_watched() -> SimpleNamespace:
     )
 
 
-def _make_show_without_ids() -> SimpleNamespace:
+def _make_show_without_ids(media_type: str = "tv") -> SimpleNamespace:
     return SimpleNamespace(
         id="media-1",
-        media_type="tv",
+        media_type=media_type,
         imdb_id=None,
         tmdb_id=None,
         tvdb_id=None,
@@ -209,3 +209,76 @@ def test_pipeline_runs_check_and_update_when_item_already_existed() -> None:
         asyncio.run(process_new_item_job(db, _make_job()))
 
     check.assert_awaited_once_with(db, "user-1", "media-1", watched_at=NOW)
+
+
+def test_dropped_show_watch_restores_and_pushes_watchlist_sync() -> None:
+    watched = _make_watched()
+    media_item = _make_show_without_ids("tv")
+    existing_item = SimpleNamespace(
+        id="wl-existing",
+        user_id="user-1",
+        media_item_id="media-1",
+        status="dropped",
+        rewatch_requested=False,
+    )
+    db = _make_db(
+        watched,
+        media_item,
+        execute_side_effects=[
+            _FakeResult(scalar=existing_item),  # ensure: item already exists
+            _FakeResult(scalar=existing_item),  # check_and_update: fetch item
+            _FakeResult(scalar=media_item),  # check_and_update: fetch media item
+        ],
+    )
+
+    with (
+        patch("librarysync.core.watch_pipeline.enrich_watched_metadata", new_callable=AsyncMock),
+        patch("librarysync.core.watch_pipeline.backfill_show_episodes", new_callable=AsyncMock),
+        patch("librarysync.core.watch_pipeline._sync_to_integrations", new_callable=AsyncMock),
+        patch(
+            "librarysync.core.watchlist.evaluate_show_watchlist_status", new_callable=AsyncMock
+        ) as evaluate,
+        patch("librarysync.core.watchlist._enqueue_watchlist_sync", new_callable=AsyncMock) as sync,
+    ):
+        asyncio.run(process_new_item_job(db, _make_job()))
+
+    assert existing_item.status == "added"
+    evaluate.assert_awaited_once_with(db, "user-1", existing_item, media_item)
+    sync.assert_awaited_once_with(db, existing_item, media_item)
+
+
+def test_dropped_anime_watch_restores_and_pushes_watchlist_sync() -> None:
+    watched = _make_watched()
+    media_item = _make_show_without_ids("anime")
+    existing_item = SimpleNamespace(
+        id="wl-existing",
+        user_id="user-1",
+        media_item_id="media-1",
+        status="dropped",
+        type="anime",
+        rewatch_requested=False,
+    )
+    db = _make_db(
+        watched,
+        media_item,
+        execute_side_effects=[
+            _FakeResult(scalar=existing_item),  # ensure: item already exists
+            _FakeResult(scalar=existing_item),  # check_and_update: fetch item
+            _FakeResult(scalar=media_item),  # check_and_update: fetch media item
+        ],
+    )
+
+    with (
+        patch("librarysync.core.watch_pipeline.enrich_watched_metadata", new_callable=AsyncMock),
+        patch("librarysync.core.watch_pipeline.backfill_show_episodes", new_callable=AsyncMock),
+        patch("librarysync.core.watch_pipeline._sync_to_integrations", new_callable=AsyncMock),
+        patch(
+            "librarysync.core.watchlist.evaluate_show_watchlist_status", new_callable=AsyncMock
+        ) as evaluate,
+        patch("librarysync.core.watchlist._enqueue_watchlist_sync", new_callable=AsyncMock) as sync,
+    ):
+        asyncio.run(process_new_item_job(db, _make_job()))
+
+    assert existing_item.status == "added"
+    evaluate.assert_awaited_once_with(db, "user-1", existing_item, media_item)
+    sync.assert_awaited_once_with(db, existing_item, media_item)

--- a/backend/tests/test_watch_pipeline_show_watchlist.py
+++ b/backend/tests/test_watch_pipeline_show_watchlist.py
@@ -244,7 +244,7 @@ def test_dropped_show_watch_restores_and_pushes_watchlist_sync() -> None:
 
     assert existing_item.status == "added"
     evaluate.assert_awaited_once_with(db, "user-1", existing_item, media_item)
-    sync.assert_awaited_once_with(db, existing_item, media_item)
+    sync.assert_awaited_once_with(db, existing_item, media_item, unhide_dropped=True)
 
 
 def test_dropped_anime_watch_restores_and_pushes_watchlist_sync() -> None:
@@ -281,4 +281,4 @@ def test_dropped_anime_watch_restores_and_pushes_watchlist_sync() -> None:
 
     assert existing_item.status == "added"
     evaluate.assert_awaited_once_with(db, "user-1", existing_item, media_item)
-    sync.assert_awaited_once_with(db, existing_item, media_item)
+    sync.assert_awaited_once_with(db, existing_item, media_item, unhide_dropped=True)

--- a/backend/tests/test_watchlist_dropped_import.py
+++ b/backend/tests/test_watchlist_dropped_import.py
@@ -1,0 +1,402 @@
+"""Tests for ingesting provider-dropped shows into the local watchlist.
+
+Covers:
+- Trakt: GET /users/hidden/dropped fetch and the dropped import pass.
+- SIMKL: dropped entries extracted from /sync/all-items in the dropped pass.
+- process_dropped_candidates: marks items dropped, links the dropped source.
+- reconcile_dropped_source: un-drops survivors, deletes orphans.
+- Watchlist imports no longer resurrect dropped items (no flip-flop).
+"""
+
+import asyncio
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from librarysync.connectors.services.trakt import TraktClient
+from librarysync.db.models import (
+    Base,
+    MediaItem,
+    User,
+    WatchlistItem,
+    WatchlistSource,
+    WatchlistSourceItem,
+)
+from librarysync.jobs import simkl_import, trakt_import
+from librarysync.jobs.watchlist_pipeline import (
+    WatchlistCandidate,
+    process_dropped_candidates,
+    process_watchlist_candidates,
+)
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+NOW = datetime(2026, 7, 18, 10, 0, tzinfo=timezone.utc)
+
+
+def _trakt_hidden_entry(trakt_id: int = 203632, tmdb_id: int = 1399) -> dict:
+    return {
+        "hidden_at": "2026-07-01T10:00:00.000Z",
+        "type": "show",
+        "show": {
+            "title": "Game of Thrones",
+            "year": 2011,
+            "ids": {"trakt": trakt_id, "tvdb": 121361, "imdb": "tt0944947", "tmdb": tmdb_id},
+        },
+    }
+
+
+def test_trakt_get_hidden_items_fetches_dropped_section() -> None:
+    client = TraktClient(client_id="trakt-client", client_secret="secret")
+    response = httpx.Response(
+        200,
+        json=[_trakt_hidden_entry()],
+        request=httpx.Request("GET", "https://api.trakt.tv/users/hidden/dropped"),
+    )
+    client._request = AsyncMock(return_value=response)  # type: ignore[method-assign]
+
+    entries = asyncio.run(
+        client.get_hidden_items("token", section="dropped", item_type="show", per_page=50)
+    )
+
+    assert len(entries) == 1
+    assert entries[0]["show"]["ids"]["trakt"] == 203632
+    client._request.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "GET",
+        "/users/hidden/dropped",
+        access_token="token",
+        params={"page": "1", "limit": "50", "type": "show"},
+    )
+
+
+def test_trakt_dropped_pass_builds_candidates_from_hidden_items() -> None:
+    integration = SimpleNamespace(user_id="user-1")
+    source = SimpleNamespace(id="src-dropped", external_id="dropped")
+    client = SimpleNamespace(
+        get_hidden_items=AsyncMock(return_value=[_trakt_hidden_entry()]),
+    )
+
+    with patch(
+        "librarysync.jobs.trakt_import.process_dropped_candidates",
+        new=AsyncMock(return_value=1),
+    ) as process:
+        imported = asyncio.run(
+            trakt_import._import_dropped_for_source(
+                None, integration, client, access_token="token", source=source, now=NOW, max_pages=1
+            )
+        )
+
+    assert imported == 1
+    process.assert_awaited_once()
+    args = process.await_args.args
+    assert args[1] == "user-1"
+    assert args[2] == "trakt"
+    assert args[3] is source
+    candidates = args[4]
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.media_type == "tv"
+    assert candidate.ids["imdb_id"] == "tt0944947"
+    assert candidate.ids["tmdb_id"] == "1399"
+    assert candidate.ids["tvdb_id"] == "121361"
+
+
+def test_trakt_dropped_pass_tolerates_fetch_failure() -> None:
+    from librarysync.connectors.services.trakt import TraktError
+
+    integration = SimpleNamespace(user_id="user-1")
+    source = SimpleNamespace(id="src-dropped", external_id="dropped")
+    client = SimpleNamespace(
+        get_hidden_items=AsyncMock(side_effect=TraktError("boom", status_code=500)),
+    )
+
+    with patch(
+        "librarysync.jobs.trakt_import.process_dropped_candidates",
+        new=AsyncMock(return_value=0),
+    ) as process:
+        imported = asyncio.run(
+            trakt_import._import_dropped_for_source(
+                None, integration, client, access_token="token", source=source, now=NOW, max_pages=1
+            )
+        )
+
+    assert imported == 0
+    process.assert_not_awaited()
+
+
+def _simkl_all_items_payload(show_status: str) -> dict:
+    return {
+        "shows": [
+            {
+                "status": show_status,
+                "show": {
+                    "title": "The Last Ship",
+                    "year": 2014,
+                    "ids": {"simkl": 42040, "imdb": "tt2402207", "tvdb": 269533},
+                },
+            }
+        ],
+        "anime": [],
+    }
+
+
+def test_simkl_dropped_pass_extracts_only_dropped_entries() -> None:
+    integration = SimpleNamespace(user_id="user-1")
+    source = SimpleNamespace(id="src-dropped", external_id="dropped")
+
+    async def fake_fetch(_token, *, category=None, **_kwargs):
+        # One dropped entry in each show category; plantowatch entries are ignored.
+        payload = _simkl_all_items_payload("dropped")
+        if category == "anime":
+            return {"shows": [], "anime": payload["shows"]}
+        return payload
+
+    client = SimpleNamespace(fetch_all_items=AsyncMock(side_effect=fake_fetch))
+
+    with patch(
+        "librarysync.jobs.simkl_import.process_dropped_candidates",
+        new=AsyncMock(return_value=2),
+    ) as process:
+        imported = asyncio.run(
+            simkl_import._import_dropped_for_source(
+                None, integration, client, access_token="token", source=source, now=NOW
+            )
+        )
+
+    assert imported == 2
+    # Movies are never fetched for the dropped pass (dropped is tv/anime only).
+    fetched_categories = [call.kwargs.get("category") for call in client.fetch_all_items.await_args_list]
+    assert fetched_categories == ["shows", "anime"]
+    candidates = process.await_args.args[4]
+    assert len(candidates) == 2
+    assert all(candidate.media_type == "tv" for candidate in candidates)
+
+
+def test_simkl_dropped_pass_ignores_other_lists() -> None:
+    integration = SimpleNamespace(user_id="user-1")
+    source = SimpleNamespace(id="src-dropped", external_id="dropped")
+
+    async def fake_fetch(_token, *, category=None, **_kwargs):
+        return _simkl_all_items_payload("plantowatch")
+
+    client = SimpleNamespace(fetch_all_items=AsyncMock(side_effect=fake_fetch))
+
+    with patch(
+        "librarysync.jobs.simkl_import.process_dropped_candidates",
+        new=AsyncMock(return_value=0),
+    ) as process:
+        imported = asyncio.run(
+            simkl_import._import_dropped_for_source(
+                None, integration, client, access_token="token", source=source, now=NOW
+            )
+        )
+
+    assert imported == 0
+    # No dropped entries anywhere -> still processes (with empty candidates) so
+    # reconcile can un-drop items that left the provider dropped list.
+    process.assert_awaited_once()
+    assert process.await_args.args[4] == []
+
+
+# ---------------------------------------------------------------------------
+# DB-backed tests for process_dropped_candidates / reconcile_dropped_source
+# ---------------------------------------------------------------------------
+
+
+async def _make_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_user_and_show(db, *, status="added", source="trakt") -> None:
+    db.add(User(id="user-1", username="user1", password_hash="x"))
+    db.add(
+        MediaItem(
+            id="show-1",
+            media_type="tv",
+            title="Some Show",
+            imdb_id="tt0944947",
+            tmdb_id="1399",
+            first_air_date=date(2020, 1, 1),
+        )
+    )
+    db.add(
+        WatchlistItem(
+            id="wl-1",
+            user_id="user-1",
+            media_item_id="show-1",
+            type="tv",
+            status=status,
+            source=source,
+        )
+    )
+    db.add(
+        WatchlistSource(
+            id="src-dropped",
+            user_id="user-1",
+            provider="trakt",
+            source_type="personal",
+            external_id="dropped",
+            name="Trakt dropped",
+        )
+    )
+    await db.commit()
+
+
+def _dropped_candidate() -> WatchlistCandidate:
+    return WatchlistCandidate(
+        entry_key=None,
+        media_type="tv",
+        ids={"imdb_id": "tt0944947", "tmdb_id": "1399"},
+        title="Some Show",
+        year=2020,
+        poster_url=None,
+        raw=None,
+        source="trakt",
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_dropped_candidates_marks_existing_item_dropped() -> None:
+    engine, session_factory = await _make_session()
+    async with session_factory() as db:
+        await _seed_user_and_show(db, status="added")
+        source = (
+            await db.execute(select(WatchlistSource).where(WatchlistSource.id == "src-dropped"))
+        ).scalars().one()
+
+        marked = await process_dropped_candidates(
+            db, "user-1", "trakt", source, [_dropped_candidate()], now=NOW
+        )
+
+        assert marked == 1
+        item = (
+            await db.execute(select(WatchlistItem).where(WatchlistItem.id == "wl-1"))
+        ).scalars().one()
+        assert item.status == "dropped"
+        link = (
+            await db.execute(
+                select(WatchlistSourceItem).where(WatchlistSourceItem.source_id == "src-dropped")
+            )
+        ).scalars().one()
+        assert link.watchlist_item_id == "wl-1"
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_process_dropped_candidates_un_drops_when_show_leaves_provider_list() -> None:
+    engine, session_factory = await _make_session()
+    async with session_factory() as db:
+        await _seed_user_and_show(db, status="dropped")
+        # A second (watchlist) source link keeps the item alive on reconcile.
+        db.add(
+            WatchlistSource(
+                id="src-watchlist",
+                user_id="user-1",
+                provider="trakt",
+                source_type="personal",
+                external_id="watchlist",
+                name="Trakt watchlist",
+            )
+        )
+        db.add(
+            WatchlistSourceItem(
+                id="link-dropped",
+                source_id="src-dropped",
+                watchlist_item_id="wl-1",
+                user_id="user-1",
+                media_item_id="show-1",
+            )
+        )
+        db.add(
+            WatchlistSourceItem(
+                id="link-watchlist",
+                source_id="src-watchlist",
+                watchlist_item_id="wl-1",
+                user_id="user-1",
+                media_item_id="show-1",
+            )
+        )
+        await db.commit()
+        source = (
+            await db.execute(select(WatchlistSource).where(WatchlistSource.id == "src-dropped"))
+        ).scalars().one()
+
+        # Empty candidate list: the show is no longer dropped on the provider.
+        marked = await process_dropped_candidates(db, "user-1", "trakt", source, [], now=NOW)
+
+        assert marked == 0
+        item = (
+            await db.execute(select(WatchlistItem).where(WatchlistItem.id == "wl-1"))
+        ).scalars().one()
+        assert item.status == "added"
+        assert (
+            await db.execute(
+                select(WatchlistSourceItem).where(WatchlistSourceItem.id == "link-dropped")
+            )
+        ).scalars().first() is None
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_process_dropped_candidates_deletes_orphaned_item() -> None:
+    engine, session_factory = await _make_session()
+    async with session_factory() as db:
+        await _seed_user_and_show(db, status="dropped")
+        db.add(
+            WatchlistSourceItem(
+                id="link-dropped",
+                source_id="src-dropped",
+                watchlist_item_id="wl-1",
+                user_id="user-1",
+                media_item_id="show-1",
+            )
+        )
+        await db.commit()
+        source = (
+            await db.execute(select(WatchlistSource).where(WatchlistSource.id == "src-dropped"))
+        ).scalars().one()
+
+        await process_dropped_candidates(db, "user-1", "trakt", source, [], now=NOW)
+
+        assert (
+            await db.execute(select(WatchlistItem).where(WatchlistItem.id == "wl-1"))
+        ).scalars().first() is None
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_watchlist_import_does_not_resurrect_dropped_item() -> None:
+    """A show present in both the provider watchlist and its dropped list must
+    stay dropped across import runs (no flip-flop)."""
+    engine, session_factory = await _make_session()
+    async with session_factory() as db:
+        await _seed_user_and_show(db, status="dropped")
+        db.add(
+            WatchlistSource(
+                id="src-watchlist",
+                user_id="user-1",
+                provider="trakt",
+                source_type="personal",
+                external_id="watchlist",
+                name="Trakt watchlist",
+            )
+        )
+        await db.commit()
+        source = (
+            await db.execute(select(WatchlistSource).where(WatchlistSource.id == "src-watchlist"))
+        ).scalars().one()
+
+        await process_watchlist_candidates(
+            db, "user-1", "trakt", source, [_dropped_candidate()], now=NOW
+        )
+
+        item = (
+            await db.execute(select(WatchlistItem).where(WatchlistItem.id == "wl-1"))
+        ).scalars().one()
+        assert item.status == "dropped"
+    await engine.dispose()

--- a/backend/tests/test_watchlist_dropped_import.py
+++ b/backend/tests/test_watchlist_dropped_import.py
@@ -15,7 +15,8 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
-from librarysync.connectors.services.trakt import TraktClient
+from librarysync.connectors.services.simkl import SimklError
+from librarysync.connectors.services.trakt import TraktClient, TraktError
 from librarysync.db.models import (
     Base,
     MediaItem,
@@ -84,7 +85,7 @@ def test_trakt_dropped_pass_builds_candidates_from_hidden_items() -> None:
     ) as process:
         imported = asyncio.run(
             trakt_import._import_dropped_for_source(
-                None, integration, client, access_token="token", source=source, now=NOW, max_pages=1
+                None, integration, client, access_token="token", source=source, now=NOW
             )
         )
 
@@ -104,8 +105,6 @@ def test_trakt_dropped_pass_builds_candidates_from_hidden_items() -> None:
 
 
 def test_trakt_dropped_pass_tolerates_fetch_failure() -> None:
-    from librarysync.connectors.services.trakt import TraktError
-
     integration = SimpleNamespace(user_id="user-1")
     source = SimpleNamespace(id="src-dropped", external_id="dropped")
     client = SimpleNamespace(
@@ -118,7 +117,7 @@ def test_trakt_dropped_pass_tolerates_fetch_failure() -> None:
     ) as process:
         imported = asyncio.run(
             trakt_import._import_dropped_for_source(
-                None, integration, client, access_token="token", source=source, now=NOW, max_pages=1
+                None, integration, client, access_token="token", source=source, now=NOW
             )
         )
 
@@ -198,6 +197,28 @@ def test_simkl_dropped_pass_ignores_other_lists() -> None:
     # reconcile can un-drop items that left the provider dropped list.
     process.assert_awaited_once()
     assert process.await_args.args[4] == []
+
+
+def test_simkl_dropped_pass_tolerates_fetch_failure() -> None:
+    integration = SimpleNamespace(user_id="user-1")
+    source = SimpleNamespace(id="src-dropped", external_id="dropped")
+    client = SimpleNamespace(
+        fetch_all_items=AsyncMock(side_effect=SimklError("boom", status_code=500)),
+    )
+
+    with patch(
+        "librarysync.jobs.simkl_import.process_dropped_candidates",
+        new=AsyncMock(return_value=0),
+    ) as process:
+        imported = asyncio.run(
+            simkl_import._import_dropped_for_source(
+                None, integration, client, access_token="token", source=source, now=NOW
+            )
+        )
+
+    assert imported == 0
+    # A failed fetch must never reconcile with an empty seen set (mass un-drop).
+    process.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -399,4 +420,69 @@ async def test_watchlist_import_does_not_resurrect_dropped_item() -> None:
             await db.execute(select(WatchlistItem).where(WatchlistItem.id == "wl-1"))
         ).scalars().one()
         assert item.status == "dropped"
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_process_dropped_candidates_clears_rewatch_request() -> None:
+    engine, session_factory = await _make_session()
+    async with session_factory() as db:
+        await _seed_user_and_show(db, status="added")
+        item = (
+            await db.execute(select(WatchlistItem).where(WatchlistItem.id == "wl-1"))
+        ).scalars().one()
+        item.rewatch_requested = True
+        item.rewatch_requested_at = NOW
+        await db.commit()
+        source = (
+            await db.execute(select(WatchlistSource).where(WatchlistSource.id == "src-dropped"))
+        ).scalars().one()
+
+        marked = await process_dropped_candidates(
+            db, "user-1", "trakt", source, [_dropped_candidate()], now=NOW
+        )
+
+        assert marked == 1
+        assert item.status == "dropped"
+        assert item.rewatch_requested is False
+        assert item.rewatch_requested_at is None
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_dropped_import_never_enqueues_provider_sync() -> None:
+    """Dropped import upserts must never echo items back out to providers."""
+    engine, session_factory = await _make_session()
+    async with session_factory() as db:
+        db.add(User(id="user-1", username="user1", password_hash="x"))
+        db.add(
+            WatchlistSource(
+                id="src-dropped",
+                user_id="user-1",
+                provider="trakt",
+                source_type="personal",
+                external_id="dropped",
+                name="Trakt dropped",
+            )
+        )
+        await db.commit()
+        source = (
+            await db.execute(select(WatchlistSource).where(WatchlistSource.id == "src-dropped"))
+        ).scalars().one()
+
+        with patch(
+            "librarysync.core.watchlist._enqueue_watchlist_sync",
+            new=AsyncMock(),
+        ) as enqueue:
+            # A brand-new show exercises the watchlist-item creation path.
+            marked = await process_dropped_candidates(
+                db, "user-1", "trakt", source, [_dropped_candidate()], now=NOW
+            )
+
+        assert marked == 1
+        item = (
+            await db.execute(select(WatchlistItem).where(WatchlistItem.user_id == "user-1"))
+        ).scalars().one()
+        assert item.status == "dropped"
+        enqueue.assert_not_awaited()
     await engine.dispose()

--- a/backend/tests/test_watchlist_from_history.py
+++ b/backend/tests/test_watchlist_from_history.py
@@ -453,4 +453,4 @@ def test_upsert_watchlist_item_enqueues_sync_on_restore_when_requested() -> None
     assert item is removed_item
     assert removed_item.status == "added"
     evaluate.assert_awaited_once_with(db, "user-1", removed_item, media_item)
-    sync.assert_awaited_once_with(db, removed_item, media_item)
+    sync.assert_awaited_once_with(db, removed_item, media_item, unhide_dropped=False)

--- a/backend/tests/test_watchlist_outbox.py
+++ b/backend/tests/test_watchlist_outbox.py
@@ -183,7 +183,7 @@ def test_simkl_watchlist_payload_uses_shows_container_for_anime() -> None:
 
     # SIMKL treats anime as shows in POST payloads (no "anime" container).
     assert payload == {
-        "shows": [{"ids": {"tmdb": 1234, "simkl": 99}}],
+        "shows": [{"ids": {"tmdb": 1234, "simkl": 99}, "to": "plantowatch"}],
     }
 
 
@@ -219,6 +219,7 @@ def test_simkl_watchlist_remove_delivery_moves_dropped_show_to_dropped_list() ->
     client = SimpleNamespace(
         add_to_list=AsyncMock(return_value=({}, 200)),
         remove_from_watchlist=AsyncMock(return_value=({}, 200)),
+        remove_history=AsyncMock(return_value=({}, 200)),
     )
     settings = SimpleNamespace(simkl_client_id="simkl-client", simkl_client_secret="secret")
 
@@ -245,6 +246,7 @@ def test_simkl_watchlist_remove_delivery_moves_dropped_show_to_dropped_list() ->
         "token",
     )
     client.remove_from_watchlist.assert_not_awaited()
+    client.remove_history.assert_not_awaited()
 
 
 def test_simkl_watchlist_remove_delivery_without_drop_removes_watchlist() -> None:
@@ -256,6 +258,7 @@ def test_simkl_watchlist_remove_delivery_without_drop_removes_watchlist() -> Non
     client = SimpleNamespace(
         add_to_list=AsyncMock(return_value=({}, 200)),
         remove_from_watchlist=AsyncMock(return_value=({}, 200)),
+        remove_history=AsyncMock(return_value=({}, 200)),
     )
     settings = SimpleNamespace(simkl_client_id="simkl-client", simkl_client_secret="secret")
 
@@ -277,10 +280,11 @@ def test_simkl_watchlist_remove_delivery_without_drop_removes_watchlist() -> Non
 
     assert response_code == 200
     assert external_id is None
-    client.remove_from_watchlist.assert_awaited_once_with(
+    client.remove_history.assert_awaited_once_with(
         {"shows": [{"ids": {"tmdb": 1399}}]},
         "token",
     )
+    client.remove_from_watchlist.assert_not_awaited()
     client.add_to_list.assert_not_awaited()
 
 
@@ -290,7 +294,7 @@ def test_simkl_watchlist_remove_delivery_removes_movie() -> None:
         payload={"media_type": "movie", "movie_ids": {"tmdb": "550"}},
     )
     integration = SimpleNamespace(id="integration-1")
-    client = SimpleNamespace(remove_from_watchlist=AsyncMock(return_value=({}, 200)))
+    client = SimpleNamespace(remove_history=AsyncMock(return_value=({}, 200)))
     settings = SimpleNamespace(simkl_client_id="simkl-client", simkl_client_secret="secret")
 
     with (
@@ -311,7 +315,7 @@ def test_simkl_watchlist_remove_delivery_removes_movie() -> None:
 
     assert response_code == 200
     assert external_id is None
-    client.remove_from_watchlist.assert_awaited_once_with(
+    client.remove_history.assert_awaited_once_with(
         {"movies": [{"ids": {"tmdb": 550}}]},
         "token",
     )
@@ -547,3 +551,97 @@ class TestPublicMetaDbWatchlistOutbox(unittest.TestCase):
         self.assertEqual(result.response_code, 200)
         self.assertIsNone(result.external_id)
         mocked.assert_awaited_once_with(None, job)
+
+
+def test_build_simkl_watchlist_payload_movie_uses_add_to_list_to_status() -> None:
+    payload = process_outbox._build_simkl_watchlist_payload(
+        {
+            "media_type": "movie",
+            "movie_ids": {"imdb": "TT0137523", "tmdb": "550"},
+        }
+    )
+    assert payload == {
+        "movies": [
+            {
+                "ids": {"imdb": "tt0137523", "tmdb": 550},
+                "to": "plantowatch",
+            }
+        ]
+    }
+
+
+def test_build_simkl_watchlist_payload_show_uses_add_to_list_to_status() -> None:
+    payload = process_outbox._build_simkl_watchlist_payload(
+        {
+            "media_type": "tv",
+            "show_ids": {"tvdb": "121361", "simkl": "1"},
+        }
+    )
+    assert payload == {
+        "shows": [
+            {
+                "ids": {"tvdb": 121361, "simkl": 1},
+                "to": "plantowatch",
+            }
+        ]
+    }
+
+
+def test_build_simkl_watchlist_remove_payload_movie_uses_full_item_payload() -> None:
+    payload = process_outbox._build_simkl_watchlist_remove_payload(
+        {
+            "media_type": "movie",
+            "movie_ids": {"imdb": "tt0137523", "tmdb": "550"},
+        }
+    )
+    assert payload == {"movies": [{"ids": {"imdb": "tt0137523", "tmdb": 550}}]}
+
+
+def test_build_simkl_watchlist_remove_payload_show_uses_full_item_payload() -> None:
+    payload = process_outbox._build_simkl_watchlist_remove_payload(
+        {
+            "media_type": "tv",
+            "show_ids": {"tvdb": "121361", "simkl": "1"},
+        }
+    )
+    assert payload == {"shows": [{"ids": {"tvdb": 121361, "simkl": 1}}]}
+
+
+def test_simkl_client_add_to_watchlist_uses_sync_add_to_list_endpoint() -> None:
+    payload = {
+        "movies": [{"ids": {"imdb": "tt0137523"}, "to": "plantowatch"}],
+    }
+    client = SimklClient(client_id="client", client_secret="secret")
+    with patch.object(
+        client,
+        "_request",
+        new=AsyncMock(return_value=httpx.Response(200, json={})),
+    ) as request:
+        asyncio.run(client.add_to_watchlist(payload, access_token="token"))
+
+    request.assert_awaited_once_with(
+        "POST",
+        "/sync/add-to-list",
+        access_token="token",
+        json_body=payload,
+    )
+
+
+def test_simkl_client_remove_from_watchlist_uses_sync_history_remove_endpoint() -> None:
+    payload = {
+        "shows": [{"ids": {"tvdb": "121361", "simkl": "1"}}],
+    }
+    client = SimklClient(client_id="client", client_secret="secret")
+    with patch.object(
+        client,
+        "_request",
+        new=AsyncMock(return_value=httpx.Response(201, json={})),
+    ) as request:
+        asyncio.run(client.remove_from_watchlist(payload, access_token="token"))
+
+    request.assert_awaited_once_with(
+        "POST",
+        "/sync/history/remove",
+        access_token="token",
+        json_body=payload,
+    )

--- a/backend/tests/test_watchlist_outbox.py
+++ b/backend/tests/test_watchlist_outbox.py
@@ -83,7 +83,7 @@ def test_trakt_watchlist_removal_uses_post_sync_watchlist_remove() -> None:
 def test_trakt_add_hidden_items_posts_to_hidden_section() -> None:
     client = TraktClient(client_id="trakt-client", client_secret="secret")
     response = httpx.Response(
-        200,
+        201,
         json={"added": {"shows": 1}},
         request=httpx.Request("POST", "https://api.trakt.tv/users/hidden/dropped"),
     )
@@ -93,7 +93,7 @@ def test_trakt_add_hidden_items_posts_to_hidden_section() -> None:
     parsed, status_code = asyncio.run(client.add_hidden_items("dropped", payload, "token"))
 
     assert parsed == {"added": {"shows": 1}}
-    assert status_code == 200
+    assert status_code == 201
     client._request.assert_awaited_once_with(  # type: ignore[attr-defined]
         "POST",
         "/users/hidden/dropped",
@@ -133,8 +133,7 @@ def test_simkl_drop_show_payload_moves_tv_show_to_dropped_list() -> None:
     )
 
     assert payload == {
-        "to": "dropped",
-        "shows": [{"ids": {"tmdb": 1399, "simkl": 42}}],
+        "shows": [{"ids": {"tmdb": 1399, "simkl": 42}, "to": "dropped"}],
     }
 
 
@@ -148,21 +147,24 @@ def test_simkl_drop_show_payload_moves_anime_to_dropped_list() -> None:
 
     # SIMKL treats anime as shows in POST payloads (no "anime" container).
     assert payload == {
-        "to": "dropped",
-        "shows": [{"ids": {"tmdb": 1234, "simkl": 99}}],
+        "shows": [{"ids": {"tmdb": 1234, "simkl": 99}, "to": "dropped"}],
     }
 
 
 def test_simkl_drop_show_calls_add_to_list_endpoint() -> None:
     client = SimklClient(client_id="simkl-client", client_secret="secret")
-    response = httpx.Response(201, json={"added": {"shows": 1}}, request=httpx.Request("POST", "https://api.simkl.com/sync/add-to-list"))
+    response = httpx.Response(
+        200,
+        json={},
+        request=httpx.Request("POST", "https://api.simkl.com/sync/add-to-list"),
+    )
     client._request = AsyncMock(return_value=response)  # type: ignore[method-assign]
 
-    payload = {"to": "dropped", "shows": [{"ids": {"tmdb": 1399}}]}
+    payload = {"shows": [{"ids": {"tmdb": 1399}, "to": "dropped"}]}
     parsed, status_code = asyncio.run(client.add_to_list(payload, "token"))
 
-    assert parsed == {"added": {"shows": 1}}
-    assert status_code == 201
+    assert parsed == {}
+    assert status_code == 200
     client._request.assert_awaited_once_with(  # type: ignore[attr-defined]
         "POST",
         "/sync/add-to-list",
@@ -208,13 +210,16 @@ def test_watchlist_sync_simkl_payload_uses_show_ids_for_anime() -> None:
     }
 
 
-def test_simkl_watchlist_remove_delivery_drops_show() -> None:
+def test_simkl_watchlist_remove_delivery_moves_dropped_show_to_dropped_list() -> None:
     job = SimpleNamespace(
         user_id="user-1",
-        payload={"media_type": "tv", "show_ids": {"tmdb": "1399"}},
+        payload={"media_type": "tv", "show_ids": {"tmdb": "1399"}, "hide_dropped": True},
     )
     integration = SimpleNamespace(id="integration-1")
-    client = SimpleNamespace(add_to_list=AsyncMock(return_value=({}, 201)))
+    client = SimpleNamespace(
+        add_to_list=AsyncMock(return_value=({}, 200)),
+        remove_from_watchlist=AsyncMock(return_value=({}, 200)),
+    )
     settings = SimpleNamespace(simkl_client_id="simkl-client", simkl_client_secret="secret")
 
     with (
@@ -233,12 +238,50 @@ def test_simkl_watchlist_remove_delivery_drops_show() -> None:
             process_outbox._deliver_simkl_watchlist_remove(None, job)
         )
 
-    assert response_code == 201
+    assert response_code == 200
     assert external_id is None
     client.add_to_list.assert_awaited_once_with(
-        {"to": "dropped", "shows": [{"ids": {"tmdb": 1399}}]},
+        {"shows": [{"ids": {"tmdb": 1399}, "to": "dropped"}]},
         "token",
     )
+    client.remove_from_watchlist.assert_not_awaited()
+
+
+def test_simkl_watchlist_remove_delivery_without_drop_removes_watchlist() -> None:
+    job = SimpleNamespace(
+        user_id="user-1",
+        payload={"media_type": "tv", "show_ids": {"tmdb": "1399"}},
+    )
+    integration = SimpleNamespace(id="integration-1")
+    client = SimpleNamespace(
+        add_to_list=AsyncMock(return_value=({}, 200)),
+        remove_from_watchlist=AsyncMock(return_value=({}, 200)),
+    )
+    settings = SimpleNamespace(simkl_client_id="simkl-client", simkl_client_secret="secret")
+
+    with (
+        patch(
+            "librarysync.jobs.process_outbox.load_integration_with_secrets",
+            new=AsyncMock(return_value=(integration, {"access_token": "token"})),
+        ),
+        patch("librarysync.jobs.process_outbox.settings", settings),
+        patch("librarysync.jobs.process_outbox.SimklClient", return_value=client),
+        patch(
+            "librarysync.jobs.process_outbox._ensure_simkl_access_token",
+            new=AsyncMock(return_value="token"),
+        ),
+    ):
+        response_code, external_id = asyncio.run(
+            process_outbox._deliver_simkl_watchlist_remove(None, job)
+        )
+
+    assert response_code == 200
+    assert external_id is None
+    client.remove_from_watchlist.assert_awaited_once_with(
+        {"shows": [{"ids": {"tmdb": 1399}}]},
+        "token",
+    )
+    client.add_to_list.assert_not_awaited()
 
 
 def test_simkl_watchlist_remove_delivery_removes_movie() -> None:
@@ -308,7 +351,7 @@ def test_trakt_watchlist_remove_delivery_hides_dropped_show() -> None:
     integration, client = _make_trakt_delivery_mocks()
     job = SimpleNamespace(
         user_id="user-1",
-        payload={"media_type": "tv", "show_ids": {"tmdb": "1399"}, "dropped": True},
+        payload={"media_type": "tv", "show_ids": {"tmdb": "1399"}, "hide_dropped": True},
     )
 
     response_code, external_id = _run_trakt_delivery(
@@ -334,7 +377,7 @@ def test_trakt_watchlist_remove_delivery_dropped_anime_uses_show_ids() -> None:
         user_id="user-1",
         # Anime ids are stored under movie_ids (Trakt add/remove mapping), but
         # the hidden dropped section only accepts show objects.
-        payload={"media_type": "anime", "movie_ids": {"tmdb": "1234"}, "dropped": True},
+        payload={"media_type": "anime", "movie_ids": {"tmdb": "1234"}, "hide_dropped": True},
     )
 
     response_code, _ = _run_trakt_delivery(
@@ -427,7 +470,7 @@ def test_trakt_removal_payload_marks_dropped_items() -> None:
     )
 
     assert payload is not None
-    assert payload["dropped"] is True
+    assert payload["hide_dropped"] is True
     assert payload["show_ids"] == {"tmdb": "1399"}
 
 
@@ -438,7 +481,46 @@ def test_trakt_removal_payload_leaves_regular_items_unmarked() -> None:
     )
 
     assert payload is not None
-    assert "dropped" not in payload
+    assert "hide_dropped" not in payload
+
+
+def _run_simkl_removal_enqueue(item_status: str) -> AsyncMock:
+    watchlist_item = SimpleNamespace(id="wl-1", user_id="user-1", type="tv", status=item_status)
+    media_item = SimpleNamespace(id="media-1", imdb_id=None, tmdb_id="1399", tvdb_id=None, raw={})
+    integration = SimpleNamespace(status="connected", config={})
+    enqueue_mock = AsyncMock()
+
+    with (
+        patch(
+            "librarysync.core.watchlist_sync.load_integration_with_secrets",
+            new=AsyncMock(return_value=(integration, {"access_token": "token"})),
+        ),
+        patch(
+            "librarysync.core.watchlist_sync.ensure_personal_watchlist_source",
+            new=AsyncMock(return_value=SimpleNamespace(is_enabled=True)),
+        ),
+        patch("librarysync.core.watchlist_sync.enqueue_outbox_job", new=enqueue_mock),
+    ):
+        asyncio.run(watchlist_sync._enqueue_simkl_watchlist_removal(None, watchlist_item, media_item))
+
+    return enqueue_mock
+
+
+def test_simkl_removal_enqueue_marks_dropped_items() -> None:
+    enqueue_mock = _run_simkl_removal_enqueue("dropped")
+
+    enqueue_mock.assert_awaited_once()
+    payload = enqueue_mock.await_args.kwargs["payload"]
+    assert payload["hide_dropped"] is True
+    assert payload["show_ids"] == {"tmdb": "1399"}
+
+
+def test_simkl_removal_enqueue_leaves_regular_items_unmarked() -> None:
+    enqueue_mock = _run_simkl_removal_enqueue("added")
+
+    enqueue_mock.assert_awaited_once()
+    payload = enqueue_mock.await_args.kwargs["payload"]
+    assert "hide_dropped" not in payload
 
 
 class TestPublicMetaDbWatchlistOutbox(unittest.TestCase):

--- a/backend/tests/test_watchlist_outbox.py
+++ b/backend/tests/test_watchlist_outbox.py
@@ -58,19 +58,67 @@ def test_publicmetadb_watchlist_payload_requires_tmdb() -> None:
     assert payload is None
 
 
-def test_trakt_watchlist_removal_uses_delete_sync_watchlist() -> None:
+def test_trakt_watchlist_removal_uses_post_sync_watchlist_remove() -> None:
     client = TraktClient(client_id="trakt-client", client_secret="secret")
-    response = httpx.Response(204, request=httpx.Request("DELETE", "https://api.trakt.tv/sync/watchlist"))
+    response = httpx.Response(
+        200,
+        json={"deleted": {"shows": 1}},
+        request=httpx.Request("POST", "https://api.trakt.tv/sync/watchlist/remove"),
+    )
     client._request = AsyncMock(return_value=response)  # type: ignore[method-assign]
 
     payload = {"shows": [{"ids": {"tmdb": 1399}}]}
     parsed, status_code = asyncio.run(client.remove_from_watchlist(payload, "token"))
 
-    assert parsed == {}
-    assert status_code == 204
+    assert parsed == {"deleted": {"shows": 1}}
+    assert status_code == 200
     client._request.assert_awaited_once_with(  # type: ignore[attr-defined]
-        "DELETE",
-        "/sync/watchlist",
+        "POST",
+        "/sync/watchlist/remove",
+        access_token="token",
+        json_body=payload,
+    )
+
+
+def test_trakt_add_hidden_items_posts_to_hidden_section() -> None:
+    client = TraktClient(client_id="trakt-client", client_secret="secret")
+    response = httpx.Response(
+        200,
+        json={"added": {"shows": 1}},
+        request=httpx.Request("POST", "https://api.trakt.tv/users/hidden/dropped"),
+    )
+    client._request = AsyncMock(return_value=response)  # type: ignore[method-assign]
+
+    payload = {"shows": [{"ids": {"tmdb": 1399}}]}
+    parsed, status_code = asyncio.run(client.add_hidden_items("dropped", payload, "token"))
+
+    assert parsed == {"added": {"shows": 1}}
+    assert status_code == 200
+    client._request.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "POST",
+        "/users/hidden/dropped",
+        access_token="token",
+        json_body=payload,
+    )
+
+
+def test_trakt_remove_hidden_items_posts_to_hidden_section_remove() -> None:
+    client = TraktClient(client_id="trakt-client", client_secret="secret")
+    response = httpx.Response(
+        200,
+        json={"deleted": {"shows": 1}},
+        request=httpx.Request("POST", "https://api.trakt.tv/users/hidden/dropped/remove"),
+    )
+    client._request = AsyncMock(return_value=response)  # type: ignore[method-assign]
+
+    payload = {"shows": [{"ids": {"tmdb": 1399}}]}
+    parsed, status_code = asyncio.run(client.remove_hidden_items("dropped", payload, "token"))
+
+    assert parsed == {"deleted": {"shows": 1}}
+    assert status_code == 200
+    client._request.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "POST",
+        "/users/hidden/dropped/remove",
         access_token="token",
         json_body=payload,
     )
@@ -98,9 +146,10 @@ def test_simkl_drop_show_payload_moves_anime_to_dropped_list() -> None:
         }
     )
 
+    # SIMKL treats anime as shows in POST payloads (no "anime" container).
     assert payload == {
         "to": "dropped",
-        "anime": [{"ids": {"tmdb": 1234, "simkl": 99}}],
+        "shows": [{"ids": {"tmdb": 1234, "simkl": 99}}],
     }
 
 
@@ -122,7 +171,7 @@ def test_simkl_drop_show_calls_add_to_list_endpoint() -> None:
     )
 
 
-def test_simkl_watchlist_payload_uses_anime_container_for_anime() -> None:
+def test_simkl_watchlist_payload_uses_shows_container_for_anime() -> None:
     payload = process_outbox._build_simkl_watchlist_payload(
         {
             "media_type": "anime",
@@ -130,8 +179,9 @@ def test_simkl_watchlist_payload_uses_anime_container_for_anime() -> None:
         }
     )
 
+    # SIMKL treats anime as shows in POST payloads (no "anime" container).
     assert payload == {
-        "anime": [{"ids": {"tmdb": 1234, "simkl": 99}}],
+        "shows": [{"ids": {"tmdb": 1234, "simkl": 99}}],
     }
 
 
@@ -222,6 +272,173 @@ def test_simkl_watchlist_remove_delivery_removes_movie() -> None:
         {"movies": [{"ids": {"tmdb": 550}}]},
         "token",
     )
+
+
+def _make_trakt_delivery_mocks() -> tuple[SimpleNamespace, SimpleNamespace]:
+    integration = SimpleNamespace(id="integration-1")
+    client = SimpleNamespace(
+        add_to_watchlist=AsyncMock(return_value=({}, 200)),
+        remove_from_watchlist=AsyncMock(return_value=({}, 200)),
+        add_hidden_items=AsyncMock(return_value=({}, 200)),
+        remove_hidden_items=AsyncMock(return_value=({}, 200)),
+    )
+    return integration, client
+
+
+def _run_trakt_delivery(deliver, client, integration, job):
+    settings = SimpleNamespace(trakt_client_id="trakt-client", trakt_client_secret="secret")
+    with (
+        patch(
+            "librarysync.jobs.process_outbox.load_integration_with_secrets",
+            new=AsyncMock(
+                return_value=(integration, {"access_token": "token", "refresh_token": "refresh"})
+            ),
+        ),
+        patch("librarysync.jobs.process_outbox.settings", settings),
+        patch("librarysync.jobs.process_outbox.TraktClient", return_value=client),
+        patch(
+            "librarysync.jobs.process_outbox._ensure_trakt_access_token",
+            new=AsyncMock(return_value="token"),
+        ),
+    ):
+        return asyncio.run(deliver(None, job))
+
+
+def test_trakt_watchlist_remove_delivery_hides_dropped_show() -> None:
+    integration, client = _make_trakt_delivery_mocks()
+    job = SimpleNamespace(
+        user_id="user-1",
+        payload={"media_type": "tv", "show_ids": {"tmdb": "1399"}, "dropped": True},
+    )
+
+    response_code, external_id = _run_trakt_delivery(
+        process_outbox._deliver_trakt_watchlist_remove, client, integration, job
+    )
+
+    assert response_code == 200
+    assert external_id is None
+    client.remove_from_watchlist.assert_awaited_once_with(
+        {"shows": [{"ids": {"tmdb": "1399"}}]},
+        "token",
+    )
+    client.add_hidden_items.assert_awaited_once_with(
+        "dropped",
+        {"shows": [{"ids": {"tmdb": "1399"}}]},
+        "token",
+    )
+
+
+def test_trakt_watchlist_remove_delivery_dropped_anime_uses_show_ids() -> None:
+    integration, client = _make_trakt_delivery_mocks()
+    job = SimpleNamespace(
+        user_id="user-1",
+        # Anime ids are stored under movie_ids (Trakt add/remove mapping), but
+        # the hidden dropped section only accepts show objects.
+        payload={"media_type": "anime", "movie_ids": {"tmdb": "1234"}, "dropped": True},
+    )
+
+    response_code, _ = _run_trakt_delivery(
+        process_outbox._deliver_trakt_watchlist_remove, client, integration, job
+    )
+
+    assert response_code == 200
+    client.add_hidden_items.assert_awaited_once_with(
+        "dropped",
+        {"shows": [{"ids": {"tmdb": "1234"}}]},
+        "token",
+    )
+
+
+def test_trakt_watchlist_remove_delivery_without_drop_skips_hidden() -> None:
+    integration, client = _make_trakt_delivery_mocks()
+    job = SimpleNamespace(
+        user_id="user-1",
+        payload={"media_type": "tv", "show_ids": {"tmdb": "1399"}},
+    )
+
+    response_code, _ = _run_trakt_delivery(
+        process_outbox._deliver_trakt_watchlist_remove, client, integration, job
+    )
+
+    assert response_code == 200
+    client.remove_from_watchlist.assert_awaited_once()
+    client.add_hidden_items.assert_not_awaited()
+
+
+def test_trakt_watchlist_add_delivery_unhides_show_from_dropped() -> None:
+    integration, client = _make_trakt_delivery_mocks()
+    job = SimpleNamespace(
+        user_id="user-1",
+        payload={"media_type": "tv", "show_ids": {"tmdb": "1399"}, "unhide_dropped": True},
+    )
+
+    response_code, _ = _run_trakt_delivery(
+        process_outbox._deliver_trakt_watchlist, client, integration, job
+    )
+
+    assert response_code == 200
+    client.add_to_watchlist.assert_awaited_once_with(
+        {"shows": [{"ids": {"tmdb": "1399"}}]},
+        "token",
+    )
+    client.remove_hidden_items.assert_awaited_once_with(
+        "dropped",
+        {"shows": [{"ids": {"tmdb": "1399"}}]},
+        "token",
+    )
+
+
+def test_trakt_watchlist_add_delivery_skips_unhide_without_flag() -> None:
+    integration, client = _make_trakt_delivery_mocks()
+    job = SimpleNamespace(
+        user_id="user-1",
+        payload={"media_type": "tv", "show_ids": {"tmdb": "1399"}},
+    )
+
+    response_code, _ = _run_trakt_delivery(
+        process_outbox._deliver_trakt_watchlist, client, integration, job
+    )
+
+    assert response_code == 200
+    client.add_to_watchlist.assert_awaited_once()
+    client.remove_hidden_items.assert_not_awaited()
+
+
+def test_trakt_watchlist_add_delivery_skips_unhide_for_movies() -> None:
+    integration, client = _make_trakt_delivery_mocks()
+    job = SimpleNamespace(
+        user_id="user-1",
+        payload={"media_type": "movie", "movie_ids": {"tmdb": "550"}, "unhide_dropped": True},
+    )
+
+    response_code, _ = _run_trakt_delivery(
+        process_outbox._deliver_trakt_watchlist, client, integration, job
+    )
+
+    assert response_code == 200
+    client.add_to_watchlist.assert_awaited_once()
+    client.remove_hidden_items.assert_not_awaited()
+
+
+def test_trakt_removal_payload_marks_dropped_items() -> None:
+    payload = watchlist_sync._build_trakt_removal_payload(
+        SimpleNamespace(id="wl-1", type="tv", status="dropped"),
+        SimpleNamespace(id="media-1", imdb_id=None, tmdb_id="1399", tvdb_id=None),
+    )
+
+    assert payload is not None
+    assert payload["dropped"] is True
+    assert payload["show_ids"] == {"tmdb": "1399"}
+
+
+def test_trakt_removal_payload_leaves_regular_items_unmarked() -> None:
+    payload = watchlist_sync._build_trakt_removal_payload(
+        SimpleNamespace(id="wl-1", type="tv", status="added"),
+        SimpleNamespace(id="media-1", imdb_id=None, tmdb_id="1399", tvdb_id=None),
+    )
+
+    assert payload is not None
+    assert "dropped" not in payload
 
 
 class TestPublicMetaDbWatchlistOutbox(unittest.TestCase):

--- a/backend/tests/test_watchlist_outbox.py
+++ b/backend/tests/test_watchlist_outbox.py
@@ -3,6 +3,9 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import httpx
+from librarysync.connectors.services.simkl import SimklClient
+from librarysync.connectors.services.trakt import TraktClient
 from librarysync.core import watch_pipeline, watchlist_sync
 from librarysync.jobs import process_outbox
 
@@ -53,6 +56,103 @@ def test_publicmetadb_watchlist_payload_requires_tmdb() -> None:
         SimpleNamespace(id="m-1", imdb_id="tt0137523", tmdb_id=None, tvdb_id=None),
     )
     assert payload is None
+
+
+def test_trakt_watchlist_removal_uses_delete_sync_watchlist() -> None:
+    client = TraktClient(client_id="trakt-client", client_secret="secret")
+    response = httpx.Response(204, request=httpx.Request("DELETE", "https://api.trakt.tv/sync/watchlist"))
+    client._request = AsyncMock(return_value=response)  # type: ignore[method-assign]
+
+    payload = {"shows": [{"ids": {"tmdb": 1399}}]}
+    parsed, status_code = asyncio.run(client.remove_from_watchlist(payload, "token"))
+
+    assert parsed == {}
+    assert status_code == 204
+    client._request.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "DELETE",
+        "/sync/watchlist",
+        access_token="token",
+        json_body=payload,
+    )
+
+
+def test_simkl_drop_show_payload_moves_tv_show_to_dropped_list() -> None:
+    payload = process_outbox._build_simkl_drop_watchlist_payload(
+        {
+            "media_type": "tv",
+            "show_ids": {"tmdb": "1399", "simkl": "42"},
+        }
+    )
+
+    assert payload == {
+        "to": "dropped",
+        "shows": [{"ids": {"tmdb": 1399, "simkl": 42}}],
+    }
+
+
+def test_simkl_drop_show_payload_moves_anime_to_dropped_list() -> None:
+    payload = process_outbox._build_simkl_drop_watchlist_payload(
+        {
+            "media_type": "anime",
+            "show_ids": {"tmdb": "1234", "simkl": "99"},
+        }
+    )
+
+    assert payload == {
+        "to": "dropped",
+        "anime": [{"ids": {"tmdb": 1234, "simkl": 99}}],
+    }
+
+
+def test_simkl_drop_show_calls_add_to_list_endpoint() -> None:
+    client = SimklClient(client_id="simkl-client", client_secret="secret")
+    response = httpx.Response(201, json={"added": {"shows": 1}}, request=httpx.Request("POST", "https://api.simkl.com/sync/add-to-list"))
+    client._request = AsyncMock(return_value=response)  # type: ignore[method-assign]
+
+    payload = {"to": "dropped", "shows": [{"ids": {"tmdb": 1399}}]}
+    parsed, status_code = asyncio.run(client.add_to_list(payload, "token"))
+
+    assert parsed == {"added": {"shows": 1}}
+    assert status_code == 201
+    client._request.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "POST",
+        "/sync/add-to-list",
+        access_token="token",
+        json_body=payload,
+    )
+
+
+def test_simkl_watchlist_remove_delivery_drops_show() -> None:
+    job = SimpleNamespace(
+        user_id="user-1",
+        payload={"media_type": "tv", "show_ids": {"tmdb": "1399"}},
+    )
+    integration = SimpleNamespace(id="integration-1")
+    client = SimpleNamespace(add_to_list=AsyncMock(return_value=({}, 201)))
+    settings = SimpleNamespace(simkl_client_id="simkl-client", simkl_client_secret="secret")
+
+    with (
+        patch(
+            "librarysync.jobs.process_outbox.load_integration_with_secrets",
+            new=AsyncMock(return_value=(integration, {"access_token": "token"})),
+        ),
+        patch("librarysync.jobs.process_outbox.settings", settings),
+        patch("librarysync.jobs.process_outbox.SimklClient", return_value=client),
+        patch(
+            "librarysync.jobs.process_outbox._ensure_simkl_access_token",
+            new=AsyncMock(return_value="token"),
+        ),
+    ):
+        response_code, external_id = asyncio.run(
+            process_outbox._deliver_simkl_watchlist_remove(None, job)
+        )
+
+    assert response_code == 201
+    assert external_id is None
+    client.add_to_list.assert_awaited_once_with(
+        {"to": "dropped", "shows": [{"ids": {"tmdb": 1399}}]},
+        "token",
+    )
 
 
 class TestPublicMetaDbWatchlistOutbox(unittest.TestCase):

--- a/backend/tests/test_watchlist_outbox.py
+++ b/backend/tests/test_watchlist_outbox.py
@@ -122,6 +122,42 @@ def test_simkl_drop_show_calls_add_to_list_endpoint() -> None:
     )
 
 
+def test_simkl_watchlist_payload_uses_anime_container_for_anime() -> None:
+    payload = process_outbox._build_simkl_watchlist_payload(
+        {
+            "media_type": "anime",
+            "show_ids": {"tmdb": "1234", "simkl": "99"},
+        }
+    )
+
+    assert payload == {
+        "anime": [{"ids": {"tmdb": 1234, "simkl": 99}}],
+    }
+
+
+def test_watchlist_sync_simkl_payload_uses_show_ids_for_anime() -> None:
+    payload = watchlist_sync._build_simkl_payload(
+        SimpleNamespace(id="wl-1", type="anime"),
+        SimpleNamespace(
+            id="media-1",
+            imdb_id="tt1234567",
+            tmdb_id="1234",
+            tvdb_id="5678",
+            raw={"simkl_id": "99"},
+        ),
+    )
+
+    assert payload is not None
+    assert "show_ids" in payload
+    assert "movie_ids" not in payload
+    assert payload["show_ids"] == {
+        "imdb": "tt1234567",
+        "tmdb": "1234",
+        "tvdb": "5678",
+        "simkl": "99",
+    }
+
+
 def test_simkl_watchlist_remove_delivery_drops_show() -> None:
     job = SimpleNamespace(
         user_id="user-1",
@@ -151,6 +187,39 @@ def test_simkl_watchlist_remove_delivery_drops_show() -> None:
     assert external_id is None
     client.add_to_list.assert_awaited_once_with(
         {"to": "dropped", "shows": [{"ids": {"tmdb": 1399}}]},
+        "token",
+    )
+
+
+def test_simkl_watchlist_remove_delivery_removes_movie() -> None:
+    job = SimpleNamespace(
+        user_id="user-1",
+        payload={"media_type": "movie", "movie_ids": {"tmdb": "550"}},
+    )
+    integration = SimpleNamespace(id="integration-1")
+    client = SimpleNamespace(remove_from_watchlist=AsyncMock(return_value=({}, 200)))
+    settings = SimpleNamespace(simkl_client_id="simkl-client", simkl_client_secret="secret")
+
+    with (
+        patch(
+            "librarysync.jobs.process_outbox.load_integration_with_secrets",
+            new=AsyncMock(return_value=(integration, {"access_token": "token"})),
+        ),
+        patch("librarysync.jobs.process_outbox.settings", settings),
+        patch("librarysync.jobs.process_outbox.SimklClient", return_value=client),
+        patch(
+            "librarysync.jobs.process_outbox._ensure_simkl_access_token",
+            new=AsyncMock(return_value="token"),
+        ),
+    ):
+        response_code, external_id = asyncio.run(
+            process_outbox._deliver_simkl_watchlist_remove(None, job)
+        )
+
+    assert response_code == 200
+    assert external_id is None
+    client.remove_from_watchlist.assert_awaited_once_with(
+        {"movies": [{"ids": {"tmdb": 550}}]},
         "token",
     )
 

--- a/backend/tests/test_watchlist_rewatch.py
+++ b/backend/tests/test_watchlist_rewatch.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -7,6 +7,15 @@ import pytest
 from fastapi import HTTPException
 from librarysync.api import routes_watchlist
 from librarysync.core import watchlist
+from librarysync.db.models import (
+    Base,
+    EpisodeItem,
+    MediaItem,
+    User,
+    WatchedItem,
+    WatchlistItem,
+)
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 
 async def _noop(*args, **kwargs):
@@ -155,6 +164,29 @@ def test_enable_watchlist_rewatch_rejects_unwatched_movie() -> None:
         asyncio.run(routes_watchlist.enable_watchlist_rewatch("wl-1", current_user, db))
 
 
+def test_enable_watchlist_rewatch_rejects_dropped_item() -> None:
+    item = SimpleNamespace(
+        id="wl-1",
+        user_id="user-1",
+        media_item_id="media-1",
+        status="dropped",
+    )
+    media_item = SimpleNamespace(id="media-1", media_type="movie")
+    db = SimpleNamespace(
+        execute=AsyncMock(return_value=_FakeResult(row=(item, media_item))),
+        commit=AsyncMock(),
+    )
+    current_user = SimpleNamespace(id="user-1")
+
+    with pytest.raises(
+        HTTPException, match="Removed or dropped watchlist items cannot be queued for rewatch"
+    ) as exc:
+        asyncio.run(routes_watchlist.enable_watchlist_rewatch("wl-1", current_user, db))
+
+    assert exc.value.status_code == 400
+    db.commit.assert_not_awaited()
+
+
 def test_set_watchlist_rewatch_request_skips_dropped_item(monkeypatch) -> None:
     monkeypatch.setattr(watchlist, "log_watchlist_event", _noop)
 
@@ -236,8 +268,8 @@ def test_drop_watchlist_item_updates_status_and_enqueues_removal(monkeypatch) ->
     clear_mock = AsyncMock(return_value=False)
     log_mock = AsyncMock()
     removal_mock = AsyncMock()
-    monkeypatch.setattr(routes_watchlist, "clear_watchlist_rewatch_request", clear_mock)
-    monkeypatch.setattr(routes_watchlist, "log_watchlist_event", log_mock)
+    monkeypatch.setattr(watchlist, "clear_watchlist_rewatch_request", clear_mock)
+    monkeypatch.setattr(watchlist, "log_watchlist_event", log_mock)
     monkeypatch.setattr(routes_watchlist, "enqueue_personal_watchlist_removal", removal_mock)
 
     response = asyncio.run(routes_watchlist.drop_watchlist_item("wl-1", current_user, db))
@@ -267,8 +299,8 @@ def test_drop_watchlist_item_rejects_movie(monkeypatch) -> None:
     clear_mock = AsyncMock(return_value=False)
     log_mock = AsyncMock()
     removal_mock = AsyncMock()
-    monkeypatch.setattr(routes_watchlist, "clear_watchlist_rewatch_request", clear_mock)
-    monkeypatch.setattr(routes_watchlist, "log_watchlist_event", log_mock)
+    monkeypatch.setattr(watchlist, "clear_watchlist_rewatch_request", clear_mock)
+    monkeypatch.setattr(watchlist, "log_watchlist_event", log_mock)
     monkeypatch.setattr(routes_watchlist, "enqueue_personal_watchlist_removal", removal_mock)
 
     with pytest.raises(HTTPException, match="Drop is only supported for TV/anime watchlist items") as exc:
@@ -344,6 +376,102 @@ def test_restore_watchlist_item_evaluates_show_before_enqueuing_sync(monkeypatch
     evaluate_mock.assert_awaited_once_with(db, "user-1", item, media_item)
     sync_mock.assert_awaited_once_with(db, item, media_item, unhide_dropped=True)
     db.commit.assert_awaited_once()
+
+
+def _make_add_watchlist_payload() -> SimpleNamespace:
+    return SimpleNamespace(
+        imdb_id=None,
+        tmdb_id="1399",
+        tvdb_id=None,
+        tvmaze_id=None,
+        kitsu_id=None,
+        myanimelist_id=None,
+        anilist_id=None,
+        media_type="tv",
+        title="Test Show",
+        year=2024,
+        poster_url=None,
+    )
+
+
+def test_add_watchlist_item_unhides_dropped_item_on_sync(monkeypatch) -> None:
+    existing_media_item = SimpleNamespace(id="media-1")
+    dropped_item = SimpleNamespace(id="wl-old", status="dropped")
+    watchlist_item = SimpleNamespace(id="wl-1", media_item_id="media-1")
+    media_item = SimpleNamespace(id="media-1", media_type="tv")
+    db = SimpleNamespace(
+        execute=AsyncMock(
+            side_effect=[
+                _FakeResult(scalar=dropped_item),
+                _FakeResult(scalar=media_item),
+            ]
+        ),
+        commit=AsyncMock(),
+        refresh=AsyncMock(),
+    )
+    current_user = SimpleNamespace(id="user-1")
+
+    sync_mock = AsyncMock()
+    monkeypatch.setattr(
+        routes_watchlist, "find_media_item_by_ids", AsyncMock(return_value=existing_media_item)
+    )
+    monkeypatch.setattr(
+        routes_watchlist,
+        "upsert_watchlist_item",
+        AsyncMock(return_value=(watchlist_item, "created")),
+    )
+    monkeypatch.setattr(
+        routes_watchlist,
+        "ensure_manual_watchlist_source",
+        AsyncMock(return_value=SimpleNamespace(id="src-1")),
+    )
+    monkeypatch.setattr(routes_watchlist, "upsert_watchlist_source_item", AsyncMock())
+    monkeypatch.setattr(routes_watchlist, "enqueue_personal_watchlist_sync", sync_mock)
+
+    response = asyncio.run(routes_watchlist.add_watchlist_item(_make_add_watchlist_payload(), current_user, db))
+
+    assert response == {"id": "wl-1", "status": "created"}
+    sync_mock.assert_awaited_once_with(db, watchlist_item, media_item, unhide_dropped=True)
+
+
+def test_add_watchlist_item_skips_unhide_for_non_dropped_item(monkeypatch) -> None:
+    existing_media_item = SimpleNamespace(id="media-1")
+    watchlist_item = SimpleNamespace(id="wl-1", media_item_id="media-1")
+    media_item = SimpleNamespace(id="media-1", media_type="tv")
+    db = SimpleNamespace(
+        execute=AsyncMock(
+            side_effect=[
+                # No dropped row for this user/media item.
+                _FakeResult(scalar=None),
+                _FakeResult(scalar=media_item),
+            ]
+        ),
+        commit=AsyncMock(),
+        refresh=AsyncMock(),
+    )
+    current_user = SimpleNamespace(id="user-1")
+
+    sync_mock = AsyncMock()
+    monkeypatch.setattr(
+        routes_watchlist, "find_media_item_by_ids", AsyncMock(return_value=existing_media_item)
+    )
+    monkeypatch.setattr(
+        routes_watchlist,
+        "upsert_watchlist_item",
+        AsyncMock(return_value=(watchlist_item, "created")),
+    )
+    monkeypatch.setattr(
+        routes_watchlist,
+        "ensure_manual_watchlist_source",
+        AsyncMock(return_value=SimpleNamespace(id="src-1")),
+    )
+    monkeypatch.setattr(routes_watchlist, "upsert_watchlist_source_item", AsyncMock())
+    monkeypatch.setattr(routes_watchlist, "enqueue_personal_watchlist_sync", sync_mock)
+
+    response = asyncio.run(routes_watchlist.add_watchlist_item(_make_add_watchlist_payload(), current_user, db))
+
+    assert response == {"id": "wl-1", "status": "created"}
+    sync_mock.assert_awaited_once_with(db, watchlist_item, media_item, unhide_dropped=False)
 
 
 def test_list_watchlist_items_excludes_dropped_for_status_all() -> None:
@@ -474,11 +602,6 @@ def test_list_watchlist_items_excludes_dropped_for_expanded_all_statuses() -> No
 async def test_list_watchlist_items_hides_dropped_show_with_watch_progress() -> None:
     """End-to-end: a dropped show must not leak into the default watchlist
     view through the computed progress status filter."""
-    from datetime import date
-
-    from librarysync.db.models import Base, EpisodeItem, MediaItem, User, WatchedItem, WatchlistItem
-    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)

--- a/backend/tests/test_watchlist_rewatch.py
+++ b/backend/tests/test_watchlist_rewatch.py
@@ -226,7 +226,7 @@ def test_drop_watchlist_item_updates_status_and_enqueues_removal(monkeypatch) ->
         status="added",
         rewatch_requested=False,
     )
-    media_item = SimpleNamespace(id="media-1", media_type="movie")
+    media_item = SimpleNamespace(id="media-1", media_type="tv")
     db = SimpleNamespace(
         execute=AsyncMock(return_value=_FakeResult(row=(item, media_item))),
         commit=AsyncMock(),
@@ -247,6 +247,39 @@ def test_drop_watchlist_item_updates_status_and_enqueues_removal(monkeypatch) ->
     clear_mock.assert_awaited_once()
     removal_mock.assert_awaited_once_with(db, item, media_item)
     db.commit.assert_awaited_once()
+
+
+def test_drop_watchlist_item_rejects_movie(monkeypatch) -> None:
+    item = SimpleNamespace(
+        id="wl-1",
+        user_id="user-1",
+        media_item_id="media-1",
+        status="added",
+        rewatch_requested=False,
+    )
+    media_item = SimpleNamespace(id="media-1", media_type="movie")
+    db = SimpleNamespace(
+        execute=AsyncMock(return_value=_FakeResult(row=(item, media_item))),
+        commit=AsyncMock(),
+    )
+    current_user = SimpleNamespace(id="user-1")
+
+    clear_mock = AsyncMock(return_value=False)
+    log_mock = AsyncMock()
+    removal_mock = AsyncMock()
+    monkeypatch.setattr(routes_watchlist, "clear_watchlist_rewatch_request", clear_mock)
+    monkeypatch.setattr(routes_watchlist, "log_watchlist_event", log_mock)
+    monkeypatch.setattr(routes_watchlist, "enqueue_personal_watchlist_removal", removal_mock)
+
+    with pytest.raises(HTTPException, match="Drop is only supported for TV/anime watchlist items") as exc:
+        asyncio.run(routes_watchlist.drop_watchlist_item("wl-1", current_user, db))
+
+    assert exc.value.status_code == 400
+    assert item.status == "added"
+    clear_mock.assert_not_awaited()
+    log_mock.assert_not_awaited()
+    removal_mock.assert_not_awaited()
+    db.commit.assert_not_awaited()
 
 
 def test_restore_watchlist_item_updates_status_and_enqueues_sync(monkeypatch) -> None:
@@ -272,6 +305,43 @@ def test_restore_watchlist_item_updates_status_and_enqueues_sync(monkeypatch) ->
 
     assert response == {"id": "wl-1", "status": "updated"}
     assert item.status == "added"
+    sync_mock.assert_awaited_once_with(db, item, media_item)
+    db.commit.assert_awaited_once()
+
+
+def test_restore_watchlist_item_evaluates_show_before_enqueuing_sync(monkeypatch) -> None:
+    item = SimpleNamespace(
+        id="wl-1",
+        user_id="user-1",
+        media_item_id="media-1",
+        status="dropped",
+    )
+    media_item = SimpleNamespace(id="media-1", media_type="anime", first_air_date=None)
+    db = SimpleNamespace(
+        execute=AsyncMock(return_value=_FakeResult(row=(item, media_item))),
+        commit=AsyncMock(),
+    )
+    current_user = SimpleNamespace(id="user-1")
+
+    log_mock = AsyncMock()
+
+    async def _set_evaluated_status(_db, _user_id, target_item, _media_item):
+        target_item.status = "in_progress"
+
+    evaluate_mock = AsyncMock(side_effect=_set_evaluated_status)
+
+    async def _assert_sync_after_eval(_db, target_item, _media_item):
+        assert target_item.status == "in_progress"
+
+    sync_mock = AsyncMock(side_effect=_assert_sync_after_eval)
+    monkeypatch.setattr(routes_watchlist, "log_watchlist_event", log_mock)
+    monkeypatch.setattr(routes_watchlist, "evaluate_show_watchlist_status", evaluate_mock)
+    monkeypatch.setattr(routes_watchlist, "enqueue_personal_watchlist_sync", sync_mock)
+
+    response = asyncio.run(routes_watchlist.restore_watchlist_item("wl-1", current_user, db))
+
+    assert response == {"id": "wl-1", "status": "updated"}
+    evaluate_mock.assert_awaited_once_with(db, "user-1", item, media_item)
     sync_mock.assert_awaited_once_with(db, item, media_item)
     db.commit.assert_awaited_once()
 
@@ -311,8 +381,10 @@ def test_list_watchlist_items_excludes_dropped_for_status_all() -> None:
 
     assert response["items"] == []
     assert len(db.queries) >= 2
-    query_sql = str(db.queries[1])
+    compiled = db.queries[1].compile()
+    query_sql = str(compiled)
     assert "watchlist_items.status !=" in query_sql
+    assert "dropped" in compiled.params.values()
 
 
 def test_list_watchlist_items_includes_dropped_when_explicitly_filtered() -> None:

--- a/backend/tests/test_watchlist_rewatch.py
+++ b/backend/tests/test_watchlist_rewatch.py
@@ -111,12 +111,19 @@ class _FakeScalarResult:
 
 
 class _FakeResult:
-    def __init__(self, *, row=None, scalar=None):
+    def __init__(self, *, row=None, scalar=None, rows=None):
         self._row = row
         self._scalar = scalar
+        self._rows = rows or []
 
     def first(self):
         return self._row
+
+    def scalar(self):
+        return self._scalar
+
+    def all(self):
+        return self._rows
 
     def scalars(self):
         return _FakeScalarResult(self._scalar)
@@ -146,3 +153,202 @@ def test_enable_watchlist_rewatch_rejects_unwatched_movie() -> None:
 
     with pytest.raises(HTTPException, match="Only watched items can be queued for rewatch"):
         asyncio.run(routes_watchlist.enable_watchlist_rewatch("wl-1", current_user, db))
+
+
+def test_set_watchlist_rewatch_request_skips_dropped_item(monkeypatch) -> None:
+    monkeypatch.setattr(watchlist, "log_watchlist_event", _noop)
+
+    item = SimpleNamespace(
+        status="dropped",
+        rewatch_requested=False,
+        rewatch_requested_at=None,
+        updated_at=None,
+    )
+
+    changed = asyncio.run(
+        watchlist.set_watchlist_rewatch_request(
+            None,
+            item,
+            "user-1",
+            "media-1",
+            enabled=True,
+            reason="manual",
+        )
+    )
+
+    assert changed is False
+    assert item.rewatch_requested is False
+
+
+def test_resolve_existing_dropped_item_restores_to_added_without_auto_evaluation(
+    monkeypatch,
+) -> None:
+    existing = SimpleNamespace(
+        status="dropped",
+        source="manual",
+        updated_at=None,
+    )
+    media_item = SimpleNamespace(id="media-1", first_air_date=None)
+    db = SimpleNamespace(execute=AsyncMock())
+
+    log_mock = AsyncMock()
+    evaluate_mock = AsyncMock()
+    enqueue_mock = AsyncMock()
+    monkeypatch.setattr(watchlist, "log_watchlist_event", log_mock)
+    monkeypatch.setattr(watchlist, "evaluate_show_watchlist_status", evaluate_mock)
+    monkeypatch.setattr(watchlist, "_enqueue_watchlist_sync", enqueue_mock)
+
+    restored_item, restored_status = asyncio.run(
+        watchlist._resolve_existing_watchlist_item(
+            db,
+            existing,
+            user_id="user-1",
+            media_item=media_item,
+            media_type="tv",
+            source="manual",
+            now=datetime(2026, 4, 17, tzinfo=timezone.utc),
+            event_raw={},
+            enqueue_sync=False,
+        )
+    )
+
+    assert restored_item is existing
+    assert restored_status == "restored"
+    assert existing.status == "added"
+    evaluate_mock.assert_not_awaited()
+
+
+def test_drop_watchlist_item_updates_status_and_enqueues_removal(monkeypatch) -> None:
+    item = SimpleNamespace(
+        id="wl-1",
+        user_id="user-1",
+        media_item_id="media-1",
+        status="added",
+        rewatch_requested=False,
+    )
+    media_item = SimpleNamespace(id="media-1", media_type="movie")
+    db = SimpleNamespace(
+        execute=AsyncMock(return_value=_FakeResult(row=(item, media_item))),
+        commit=AsyncMock(),
+    )
+    current_user = SimpleNamespace(id="user-1")
+
+    clear_mock = AsyncMock(return_value=False)
+    log_mock = AsyncMock()
+    removal_mock = AsyncMock()
+    monkeypatch.setattr(routes_watchlist, "clear_watchlist_rewatch_request", clear_mock)
+    monkeypatch.setattr(routes_watchlist, "log_watchlist_event", log_mock)
+    monkeypatch.setattr(routes_watchlist, "enqueue_personal_watchlist_removal", removal_mock)
+
+    response = asyncio.run(routes_watchlist.drop_watchlist_item("wl-1", current_user, db))
+
+    assert response == {"id": "wl-1", "status": "updated"}
+    assert item.status == "dropped"
+    clear_mock.assert_awaited_once()
+    removal_mock.assert_awaited_once_with(db, item, media_item)
+    db.commit.assert_awaited_once()
+
+
+def test_restore_watchlist_item_updates_status_and_enqueues_sync(monkeypatch) -> None:
+    item = SimpleNamespace(
+        id="wl-1",
+        user_id="user-1",
+        media_item_id="media-1",
+        status="dropped",
+    )
+    media_item = SimpleNamespace(id="media-1", media_type="movie")
+    db = SimpleNamespace(
+        execute=AsyncMock(return_value=_FakeResult(row=(item, media_item))),
+        commit=AsyncMock(),
+    )
+    current_user = SimpleNamespace(id="user-1")
+
+    log_mock = AsyncMock()
+    sync_mock = AsyncMock()
+    monkeypatch.setattr(routes_watchlist, "log_watchlist_event", log_mock)
+    monkeypatch.setattr(routes_watchlist, "enqueue_personal_watchlist_sync", sync_mock)
+
+    response = asyncio.run(routes_watchlist.restore_watchlist_item("wl-1", current_user, db))
+
+    assert response == {"id": "wl-1", "status": "updated"}
+    assert item.status == "added"
+    sync_mock.assert_awaited_once_with(db, item, media_item)
+    db.commit.assert_awaited_once()
+
+
+def test_list_watchlist_items_excludes_dropped_for_status_all() -> None:
+    class _QueryCaptureDB:
+        def __init__(self):
+            self.queries = []
+
+        async def execute(self, query):
+            self.queries.append(query)
+            if len(self.queries) == 1:
+                return _FakeResult(scalar=0)
+            return _FakeResult(rows=[])
+
+        async def commit(self):
+            return None
+
+    db = _QueryCaptureDB()
+    current_user = SimpleNamespace(id="user-1")
+
+    response = asyncio.run(
+        routes_watchlist.list_watchlist_items(
+            limit=100,
+            offset=0,
+            status="all",
+            media_type=None,
+            search=None,
+            source=None,
+            rewatch="all",
+            order_by="date_added",
+            order_dir="desc",
+            current_user=current_user,
+            db=db,
+        )
+    )
+
+    assert response["items"] == []
+    assert len(db.queries) >= 2
+    query_sql = str(db.queries[1])
+    assert "watchlist_items.status !=" in query_sql
+
+
+def test_list_watchlist_items_includes_dropped_when_explicitly_filtered() -> None:
+    class _QueryCaptureDB:
+        def __init__(self):
+            self.queries = []
+
+        async def execute(self, query):
+            self.queries.append(query)
+            if len(self.queries) == 1:
+                return _FakeResult(scalar=0)
+            return _FakeResult(rows=[])
+
+        async def commit(self):
+            return None
+
+    db = _QueryCaptureDB()
+    current_user = SimpleNamespace(id="user-1")
+
+    response = asyncio.run(
+        routes_watchlist.list_watchlist_items(
+            limit=100,
+            offset=0,
+            status="dropped",
+            media_type=None,
+            search=None,
+            source=None,
+            rewatch="all",
+            order_by="date_added",
+            order_dir="desc",
+            current_user=current_user,
+            db=db,
+        )
+    )
+
+    assert response["items"] == []
+    assert len(db.queries) >= 2
+    query_sql = str(db.queries[1])
+    assert "watchlist_items.status !=" not in query_sql

--- a/backend/tests/test_watchlist_rewatch.py
+++ b/backend/tests/test_watchlist_rewatch.py
@@ -305,7 +305,7 @@ def test_restore_watchlist_item_updates_status_and_enqueues_sync(monkeypatch) ->
 
     assert response == {"id": "wl-1", "status": "updated"}
     assert item.status == "added"
-    sync_mock.assert_awaited_once_with(db, item, media_item)
+    sync_mock.assert_awaited_once_with(db, item, media_item, unhide_dropped=True)
     db.commit.assert_awaited_once()
 
 
@@ -330,7 +330,7 @@ def test_restore_watchlist_item_evaluates_show_before_enqueuing_sync(monkeypatch
 
     evaluate_mock = AsyncMock(side_effect=_set_evaluated_status)
 
-    async def _assert_sync_after_eval(_db, target_item, _media_item):
+    async def _assert_sync_after_eval(_db, target_item, _media_item, **_kwargs):
         assert target_item.status == "in_progress"
 
     sync_mock = AsyncMock(side_effect=_assert_sync_after_eval)
@@ -342,7 +342,7 @@ def test_restore_watchlist_item_evaluates_show_before_enqueuing_sync(monkeypatch
 
     assert response == {"id": "wl-1", "status": "updated"}
     evaluate_mock.assert_awaited_once_with(db, "user-1", item, media_item)
-    sync_mock.assert_awaited_once_with(db, item, media_item)
+    sync_mock.assert_awaited_once_with(db, item, media_item, unhide_dropped=True)
     db.commit.assert_awaited_once()
 
 
@@ -424,3 +424,142 @@ def test_list_watchlist_items_includes_dropped_when_explicitly_filtered() -> Non
     assert len(db.queries) >= 2
     query_sql = str(db.queries[1])
     assert "watchlist_items.status !=" not in query_sql
+
+
+def test_list_watchlist_items_excludes_dropped_for_expanded_all_statuses() -> None:
+    """The UI's default "All" view sends an expanded status list, not the
+    literal "all"; dropped items must stay hidden there as well."""
+
+    class _QueryCaptureDB:
+        def __init__(self):
+            self.queries = []
+
+        async def execute(self, query):
+            self.queries.append(query)
+            if len(self.queries) == 1:
+                return _FakeResult(scalar=0)
+            return _FakeResult(rows=[])
+
+        async def commit(self):
+            return None
+
+    db = _QueryCaptureDB()
+    current_user = SimpleNamespace(id="user-1")
+
+    response = asyncio.run(
+        routes_watchlist.list_watchlist_items(
+            limit=100,
+            offset=0,
+            # Exactly what page-watchlist.js sends for the default "All" filter.
+            status="added,in_progress,not_released,active,waiting,watched",
+            media_type=None,
+            search=None,
+            source=None,
+            rewatch="all",
+            order_by="date_added",
+            order_dir="desc",
+            current_user=current_user,
+            db=db,
+        )
+    )
+
+    assert response["items"] == []
+    assert len(db.queries) >= 2
+    compiled = db.queries[1].compile()
+    assert "watchlist_items.status !=" in str(compiled)
+    assert "dropped" in compiled.params.values()
+
+
+@pytest.mark.asyncio
+async def test_list_watchlist_items_hides_dropped_show_with_watch_progress() -> None:
+    """End-to-end: a dropped show must not leak into the default watchlist
+    view through the computed progress status filter."""
+    from datetime import date
+
+    from librarysync.db.models import Base, EpisodeItem, MediaItem, User, WatchedItem, WatchlistItem
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with session_factory() as db:
+        db.add(User(id="user-1", username="user1", password_hash="x"))
+        db.add(
+            MediaItem(
+                id="show-1",
+                media_type="tv",
+                title="Dropped Show",
+                first_air_date=date(2024, 1, 1),
+            )
+        )
+        for ep_id, num in (("ep-1", 1), ("ep-2", 2)):
+            db.add(
+                EpisodeItem(
+                    id=ep_id,
+                    show_media_item_id="show-1",
+                    season_number=1,
+                    episode_number=num,
+                    air_date=date(2024, 1, num),
+                )
+            )
+        # One of two released episodes watched -> computed status "in_progress",
+        # which is part of the default "All" status filter.
+        db.add(
+            WatchedItem(
+                id="w-1",
+                user_id="user-1",
+                episode_item_id="ep-1",
+                watched_at=datetime(2024, 2, 1, tzinfo=timezone.utc),
+            )
+        )
+        db.add(
+            WatchlistItem(
+                id="wl-1",
+                user_id="user-1",
+                media_item_id="show-1",
+                type="tv",
+                status="dropped",
+                source="manual",
+            )
+        )
+        await db.commit()
+
+    current_user = SimpleNamespace(id="user-1")
+
+    async with session_factory() as db:
+        response = await routes_watchlist.list_watchlist_items(
+            limit=100,
+            offset=0,
+            status="added,in_progress,not_released,active,waiting,watched",
+            media_type=None,
+            search=None,
+            source=None,
+            rewatch="all",
+            order_by="date_added",
+            order_dir="desc",
+            current_user=current_user,
+            db=db,
+        )
+        assert [item["title"] for item in response["items"]] == []
+        assert response["total"] == 0
+
+    async with session_factory() as db:
+        response = await routes_watchlist.list_watchlist_items(
+            limit=100,
+            offset=0,
+            status="dropped",
+            media_type=None,
+            search=None,
+            source=None,
+            rewatch="all",
+            order_by="date_added",
+            order_dir="desc",
+            current_user=current_user,
+            db=db,
+        )
+        assert [item["title"] for item in response["items"]] == ["Dropped Show"]
+        assert response["total"] == 1
+
+    await engine.dispose()


### PR DESCRIPTION
## Summary
- add a first-class `dropped` watchlist status for TV shows and anime
- keep dropped items hidden from the default watchlist view while adding an explicit Dropped filter
- drop TV/anime through `POST /api/watchlist/items/{id}/drop` and restore through `DELETE /api/watchlist/items/{id}/drop`
- reject movie drops so movies continue to use normal remove semantics
- move SIMKL TV/anime drops to the provider dropped list through `/sync/add-to-list`
- keep SIMKL anime payloads consistent by using the `anime` container for watchlist add/drop delivery
- restore dropped TV/anime back into the active watchlist when they are watched again, then enqueue provider watchlist sync so Trakt/SIMKL receive the updated status
- evaluate restored TV/anime before provider sync so the pushed watchlist state reflects current progress
- remove Trakt items from watchlist through `DELETE /sync/watchlist`
- add endpoint, payload, delivery, restore-on-watch, and filtering coverage

## Verification
- `uv run pytest tests/test_watch_pipeline_show_watchlist.py tests/test_watchlist_outbox.py tests/test_watchlist_rewatch.py` (33 passed)
- `uv run pytest` (281 passed)
- `uv run ruff check`
- `node --check backend/src/librarysync/static/page-watchlist.js`
- `git diff --check`