### PR TITLE
Guard import media ID conflicts

### DIFF
--- a/backend/src/librarysync/jobs/aiostreams_import.py
+++ b/backend/src/librarysync/jobs/aiostreams_import.py
@@ -935,7 +935,7 @@ async def _get_or_create_movie_item(
         entry.year,
     )
     if item:
-        _apply_media_updates(item, entry)
+        await _apply_media_updates(db, item, entry)
         return item
     if not entry.imdb_id and not entry.tmdb_id and not entry.tvdb_id and not entry.title:
         return None
@@ -969,7 +969,7 @@ async def _get_or_create_show_item(
         entry.year,
     )
     if item:
-        _apply_media_updates(item, entry)
+        await _apply_media_updates(db, item, entry)
         return item
     if not entry.imdb_id and not entry.tmdb_id and not entry.tvdb_id and not entry.title:
         return None
@@ -1061,19 +1061,67 @@ async def _find_media_item(
     return item
 
 
-def _apply_media_updates(item: MediaItem, entry: ParsedEntry) -> None:
-    if entry.imdb_id and not item.imdb_id:
-        item.imdb_id = entry.imdb_id
-    if entry.tmdb_id and not item.tmdb_id:
-        item.tmdb_id = entry.tmdb_id
-    if entry.tvdb_id and not item.tvdb_id:
-        item.tvdb_id = entry.tvdb_id
+async def _apply_media_updates(
+    db: AsyncSession,
+    item: MediaItem,
+    entry: ParsedEntry,
+) -> None:
+    await _maybe_set_media_id(db, item, "imdb_id", entry.imdb_id)
+    await _maybe_set_media_id(db, item, "tmdb_id", entry.tmdb_id)
+    await _maybe_set_media_id(db, item, "tvdb_id", entry.tvdb_id)
     if entry.year is not None and item.year is None:
         item.year = entry.year
     if entry.title and (not item.title or item.title.startswith("AIOStreams ")):
         item.title = entry.title
     if item.raw is None:
         item.raw = _build_media_raw(item.media_type)
+
+
+async def _maybe_set_media_id(
+    db: AsyncSession,
+    item: MediaItem,
+    field: str,
+    value: str | None,
+) -> None:
+    if not value or getattr(item, field):
+        return
+    if await _can_assign_media_id(db, item, field, value):
+        setattr(item, field, value)
+    else:
+        logger.warning(
+            "Skipping %s=%s for media item %s due to conflict",
+            field,
+            value,
+            item.id,
+        )
+
+
+async def _can_assign_media_id(
+    db: AsyncSession,
+    item: MediaItem,
+    field: str,
+    value: str,
+) -> bool:
+    if field == "imdb_id":
+        result = await db.execute(select(MediaItem.id).where(MediaItem.imdb_id == value))
+    elif field == "tmdb_id":
+        result = await db.execute(
+            select(MediaItem.id).where(
+                MediaItem.tmdb_id == value,
+                MediaItem.media_type == item.media_type,
+            )
+        )
+    elif field == "tvdb_id":
+        result = await db.execute(
+            select(MediaItem.id).where(
+                MediaItem.tvdb_id == value,
+                MediaItem.media_type == item.media_type,
+            )
+        )
+    else:
+        return False
+    existing = result.scalars().first()
+    return existing is None or existing == item.id
 
 
 def _build_media_raw(media_type: str) -> dict[str, Any]:

--- a/backend/src/librarysync/jobs/publicmetadb_import.py
+++ b/backend/src/librarysync/jobs/publicmetadb_import.py
@@ -324,7 +324,15 @@ async def _get_or_create_movie_item(
         db.add(item)
         await db.flush()
         return item
-    _apply_media_updates(item, movie.title, movie.year, movie.tmdb_id, movie.imdb_id, movie.tvdb_id)
+    await _apply_media_updates(
+        db,
+        item,
+        movie.title,
+        movie.year,
+        movie.tmdb_id,
+        movie.imdb_id,
+        movie.tvdb_id,
+    )
     _apply_media_raw(item, movie.raw)
     return item
 
@@ -352,7 +360,8 @@ async def _get_or_create_show_item(
         db.add(item)
         await db.flush()
         return item
-    _apply_media_updates(
+    await _apply_media_updates(
+        db,
         item,
         episode.show_title,
         episode.year,
@@ -428,7 +437,8 @@ async def _find_media_item(
     return None
 
 
-def _apply_media_updates(
+async def _apply_media_updates(
+    db: AsyncSession,
     item: MediaItem,
     title: str,
     year: int | None,
@@ -440,12 +450,56 @@ def _apply_media_updates(
         item.title = title
     if year and not item.year:
         item.year = year
-    if tmdb_id and not item.tmdb_id:
-        item.tmdb_id = tmdb_id
-    if imdb_id and not item.imdb_id:
-        item.imdb_id = imdb_id
-    if tvdb_id and not item.tvdb_id:
-        item.tvdb_id = tvdb_id
+    await _maybe_set_media_id(db, item, "tmdb_id", tmdb_id)
+    await _maybe_set_media_id(db, item, "imdb_id", imdb_id)
+    await _maybe_set_media_id(db, item, "tvdb_id", tvdb_id)
+
+
+async def _maybe_set_media_id(
+    db: AsyncSession,
+    item: MediaItem,
+    field: str,
+    value: str | None,
+) -> None:
+    if not value or getattr(item, field):
+        return
+    if await _can_assign_media_id(db, item, field, value):
+        setattr(item, field, value)
+    else:
+        logger.warning(
+            "Skipping %s=%s for media item %s due to conflict",
+            field,
+            value,
+            item.id,
+        )
+
+
+async def _can_assign_media_id(
+    db: AsyncSession,
+    item: MediaItem,
+    field: str,
+    value: str,
+) -> bool:
+    if field == "imdb_id":
+        result = await db.execute(select(MediaItem.id).where(MediaItem.imdb_id == value))
+    elif field == "tmdb_id":
+        result = await db.execute(
+            select(MediaItem.id).where(
+                MediaItem.tmdb_id == value,
+                MediaItem.media_type == item.media_type,
+            )
+        )
+    elif field == "tvdb_id":
+        result = await db.execute(
+            select(MediaItem.id).where(
+                MediaItem.tvdb_id == value,
+                MediaItem.media_type == item.media_type,
+            )
+        )
+    else:
+        return False
+    existing = result.scalars().first()
+    return existing is None or existing == item.id
 
 
 def _apply_media_raw(item: MediaItem, payload: dict[str, Any]) -> None:

--- a/backend/tests/test_aiostreams_import.py
+++ b/backend/tests/test_aiostreams_import.py
@@ -9,6 +9,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(PROJECT_ROOT / "src"))
 
 from librarysync.connectors.metadata.base import MediaCandidate  # noqa: E402
+from librarysync.db.models import MediaItem  # noqa: E402
 from librarysync.jobs import aiostreams_import  # noqa: E402
 
 
@@ -20,6 +21,9 @@ class TestAIOStreamsLookup(unittest.TestCase):
         media_type: str = "movie",
         season_number: int | None = None,
         episode_number: int | None = None,
+        imdb_id: str | None = None,
+        tmdb_id: str | None = None,
+        tvdb_id: str | None = None,
     ) -> aiostreams_import.ParsedEntry:
         now = datetime.now(timezone.utc)
         return aiostreams_import.ParsedEntry(
@@ -28,9 +32,9 @@ class TestAIOStreamsLookup(unittest.TestCase):
             last_seen=now,
             duration_seconds=3600,
             media_type=media_type,
-            imdb_id=None,
-            tmdb_id=None,
-            tvdb_id=None,
+            imdb_id=imdb_id,
+            tmdb_id=tmdb_id,
+            tvdb_id=tvdb_id,
             season_number=season_number,
             episode_number=episode_number,
             title=title,
@@ -174,6 +178,26 @@ class TestAIOStreamsLookup(unittest.TestCase):
         self.assertIsNotNone(selected)
         self.assertEqual(selected.imdb_id, "tt12345678")
         self.assertEqual(selected.year, 2024)
+
+    def test_apply_media_updates_skips_conflicting_imdb_id(self) -> None:
+        entry = self._build_entry("Example Movie", 2020, imdb_id="tt31909098")
+        item = MediaItem(
+            id="target-media-id",
+            media_type="movie",
+            title="Existing title",
+            imdb_id=None,
+        )
+
+        db = AsyncMock()
+        conflict_result = MagicMock()
+        conflict_result.scalars.return_value.first.return_value = "other-media-id"
+        db.execute = AsyncMock(return_value=conflict_result)
+
+        asyncio.run(aiostreams_import._apply_media_updates(db, item, entry))
+
+        self.assertIsNone(item.imdb_id)
+        self.assertEqual(item.title, "Existing title")
+        self.assertEqual(item.year, 2020)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_publicmetadb_import.py
+++ b/backend/tests/test_publicmetadb_import.py
@@ -1,10 +1,11 @@
 import asyncio
 import unittest
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from librarysync.core.import_all import DEFAULT_IMPORT_QUEUE_ORDER, normalize_import_queue_order
-from librarysync.db.models import Integration
+from librarysync.db.models import Integration, MediaItem
+from librarysync.jobs import publicmetadb_import
 from librarysync.jobs.import_base import ImportContext
 from librarysync.jobs.publicmetadb_import import PublicMetaDbImportStrategy
 
@@ -141,6 +142,35 @@ class TestPublicMetaDbImport(unittest.TestCase):
         self.assertTrue(result.attempted)
         self.assertEqual(result.imported, 0)
         mocked_process.assert_not_awaited()
+
+    def test_apply_media_updates_skips_conflicting_imdb_id(self) -> None:
+        db = AsyncMock()
+        conflict_result = MagicMock()
+        conflict_result.scalars.return_value.first.return_value = "other-media-id"
+        db.execute = AsyncMock(return_value=conflict_result)
+
+        item = MediaItem(
+            id="target-media-id",
+            media_type="movie",
+            title="Existing title",
+            imdb_id=None,
+        )
+
+        asyncio.run(
+            publicmetadb_import._apply_media_updates(
+                db,
+                item,
+                "Updated title",
+                2024,
+                None,
+                "tt31909098",
+                None,
+            )
+        )
+
+        self.assertIsNone(item.imdb_id)
+        self.assertEqual(item.title, "Existing title")
+        self.assertEqual(item.year, 2024)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add conflict-safe media external ID assignment in PublicMetaDB imports
- add the same guard for AIOStreams import updates
- cover conflicting IMDb ID updates with focused tests

## Verification
- uv run pytest
- uv run ruff check